### PR TITLE
feat: edicion de facturas de venta en borrador, fix fechas timezone, …

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -418,8 +418,8 @@
       "description": "Manage all organizations you own"
     },
     "branding": {
-      "title": "Branding & Website",
-      "description": "Configure the branding and public website of your organization",
+      "title": "Website",
+      "description": "Configure the public website of your organization",
       "refresh": "Refresh",
       "published": "Published",
       "draft": "Draft",
@@ -1503,7 +1503,7 @@
     "chat": "Chat",
     "myOrganization": "My Organization",
     "information": "Information",
-    "branding": "Branding",
+    "branding": "Website",
     "domains": "Domains",
     "members": "Members",
     "invitations": "Invitations",

--- a/messages/es.json
+++ b/messages/es.json
@@ -418,8 +418,8 @@
       "description": "Gestiona todas las organizaciones de las que eres propietario"
     },
     "branding": {
-      "title": "Branding & Sitio Web",
-      "description": "Configura el branding y sitio web público de tu organización",
+      "title": "Sitio Web",
+      "description": "Configura el sitio web público de tu organización",
       "refresh": "Actualizar",
       "published": "Publicado",
       "draft": "Borrador",
@@ -1503,7 +1503,7 @@
     "chat": "Chat",
     "myOrganization": "Mi Organización",
     "information": "Información",
-    "branding": "Branding",
+    "branding": "Sitio Web",
     "domains": "Dominios",
     "members": "Miembros",
     "invitations": "Invitaciones",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -418,8 +418,8 @@
       "description": "Gérez toutes les organisations dont vous êtes propriétaire"
     },
     "branding": {
-      "title": "Branding & Site Web",
-      "description": "Configurez le branding et le site web public de votre organisation",
+      "title": "Site Web",
+      "description": "Configurez le site web public de votre organisation",
       "refresh": "Actualiser",
       "published": "Publié",
       "draft": "Brouillon",
@@ -1503,7 +1503,7 @@
     "chat": "Chat",
     "myOrganization": "Mon Organisation",
     "information": "Information",
-    "branding": "Branding",
+    "branding": "Site Web",
     "domains": "Domaines",
     "members": "Membres",
     "invitations": "Invitations",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -418,8 +418,8 @@
       "description": "Gerencie todas as organizações das quais você é proprietário"
     },
     "branding": {
-      "title": "Branding & Site",
-      "description": "Configure o branding e o site público da sua organização",
+      "title": "Site Web",
+      "description": "Configure o site público da sua organização",
       "refresh": "Atualizar",
       "published": "Publicado",
       "draft": "Rascunho",
@@ -1503,7 +1503,7 @@
     "chat": "Chat",
     "myOrganization": "Minha Organização",
     "information": "Informação",
-    "branding": "Branding",
+    "branding": "Site Web",
     "domains": "Domínios",
     "members": "Membros",
     "invitations": "Convites",

--- a/src/app/app/finanzas/facturas-venta/[id]/editar/page.tsx
+++ b/src/app/app/finanzas/facturas-venta/[id]/editar/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+import { EditarFacturaVenta } from '@/components/finanzas/facturas-venta/editar/EditarFacturaVenta';
+
+interface PageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default function EditarFacturaPage({ params }: PageProps) {
+  const { id } = React.use(params);
+  return <EditarFacturaVenta facturaId={id} />;
+}

--- a/src/components/app-layout/AppLayout.tsx
+++ b/src/components/app-layout/AppLayout.tsx
@@ -289,7 +289,7 @@ const MODULES_WITH_SUBMENU: NavItemProps[] = [
     icon: <Building2 size={18} />,
     submenu: [
       { name: "Información", href: "/app/organizacion/informacion", icon: <Building2 size={16} /> },
-      { name: "Branding", href: "/app/organizacion/branding", icon: <Palette size={16} /> },
+      { name: "Sitio Web", href: "/app/organizacion/branding", icon: <Palette size={16} /> },
       { name: "Dominios", href: "/app/organizacion/dominios", icon: <Globe size={16} /> },
       { name: "Miembros", href: "/app/organizacion/miembros", icon: <Users size={16} /> },
       { name: "Invitaciones", href: "/app/organizacion/invitaciones", icon: <Plus size={16} /> },

--- a/src/components/app-layout/Sidebar/SidebarNavigation.tsx
+++ b/src/components/app-layout/Sidebar/SidebarNavigation.tsx
@@ -398,7 +398,7 @@ const SidebarNavigationComponent = ({
           icon: <Building2 size={18} />,
           submenu: [
             { name: "Información", href: "/app/organizacion/informacion", icon: <Building2 size={16} /> },
-            { name: "Branding", href: "/app/organizacion/branding", icon: <Palette size={16} /> },
+            { name: "Sitio Web", href: "/app/organizacion/branding", icon: <Palette size={16} /> },
             { name: "Dominios", href: "/app/organizacion/dominios", icon: <Globe size={16} /> },
             { name: "Miembros", href: "/app/organizacion/miembros", icon: <Users size={16} /> },
             { name: "Invitaciones", href: "/app/organizacion/invitaciones", icon: <Plus size={16} /> },

--- a/src/components/app-layout/Sidebar/SubMenuPanel.tsx
+++ b/src/components/app-layout/Sidebar/SubMenuPanel.tsx
@@ -212,7 +212,7 @@ const getSubmenuIcon = (name: string): React.ReactNode => {
     'Mi Plan': <CreditCard size={16} />,
     'Módulos': <Package size={16} />,
     'Dominios': <Globe size={16} />,
-    'Branding': <Palette size={16} />,
+    'Sitio Web': <Palette size={16} />,
     'Sucursales': <MapPin size={16} />,
     'Mis Organizaciones': <Building2 size={16} />,
     

--- a/src/components/finanzas/facturas-compra/nueva-factura/InformacionBasicaForm.tsx
+++ b/src/components/finanzas/facturas-compra/nueva-factura/InformacionBasicaForm.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { supabase } from '@/lib/supabase/config';
 import { getOrganizationId, getCurrentBranchId } from '@/lib/hooks/useOrganization';
-import { parseLocalDate } from '@/utils/Utils';
+import { parseLocalDate, toLocalDateString } from '@/utils/Utils';
 import {
   Select,
   SelectContent,
@@ -191,7 +191,7 @@ export function InformacionBasicaForm({
       const issueDate = parseLocalDate(formData.issue_date);
       const newDueDate = new Date(issueDate);
       newDueDate.setDate(newDueDate.getDate() + days);
-      onInputChange('due_date', newDueDate.toISOString().split('T')[0]);
+      onInputChange('due_date', toLocalDateString(newDueDate));
     }
   };
   

--- a/src/components/finanzas/facturas-compra/nueva-factura/NuevaFacturaForm.tsx
+++ b/src/components/finanzas/facturas-compra/nueva-factura/NuevaFacturaForm.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { FacturasCompraService } from '../FacturasCompraService';
-import { parseLocalDate } from '@/utils/Utils';
+import { parseLocalDate, toLocalDateString } from '@/utils/Utils';
 import { 
   NuevaFacturaCompraForm, 
   InvoiceItemForm, 
@@ -67,7 +67,7 @@ export function NuevaFacturaForm({
       return {
         supplier_id: facturaInicial.supplier_id,
         number_ext: facturaInicial.number_ext,
-        issue_date: facturaInicial.issue_date ? facturaInicial.issue_date.split('T')[0] : new Date().toISOString().split('T')[0],
+        issue_date: facturaInicial.issue_date ? facturaInicial.issue_date.split('T')[0] : toLocalDateString(new Date()),
         due_date: facturaInicial.due_date ? facturaInicial.due_date.split('T')[0] : '',
         currency: facturaInicial.currency || 'COP',
         payment_terms: facturaInicial.payment_terms || 30,
@@ -86,7 +86,7 @@ export function NuevaFacturaForm({
     return {
       supplier_id: null,
       number_ext: '',
-      issue_date: new Date().toISOString().split('T')[0],
+      issue_date: toLocalDateString(new Date()),
       due_date: '',
       currency: 'COP',
       payment_terms: 30,
@@ -128,7 +128,7 @@ export function NuevaFacturaForm({
     if (formData.issue_date && formData.payment_terms) {
       const fechaEmision = parseLocalDate(formData.issue_date);
       fechaEmision.setDate(fechaEmision.getDate() + formData.payment_terms);
-      const fechaVencimiento = fechaEmision.toISOString().split('T')[0];
+      const fechaVencimiento = toLocalDateString(fechaEmision);
       
       setFormData(prev => ({ ...prev, due_date: fechaVencimiento }));
     }

--- a/src/components/finanzas/facturas-venta/FacturasTable.tsx
+++ b/src/components/finanzas/facturas-venta/FacturasTable.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { MoreVertical, Eye, Printer, Mail, Send, AlertTriangle, ChevronDown, ChevronRight, CreditCard, FileText } from 'lucide-react';
+import { MoreVertical, Eye, Printer, Mail, Send, AlertTriangle, ChevronDown, ChevronRight, CreditCard, FileText, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -585,6 +585,22 @@ export function FacturasTable({ filtros }: FacturasTableProps = {}) {
                       <Eye className="mr-2 h-4 w-4 flex-shrink-0" />
                       <span>Ver</span>
                     </DropdownMenuItem>
+                    {factura.status === 'draft' && (
+                      <DropdownMenuItem
+                        className="
+                          cursor-pointer text-sm
+                          text-gray-700 dark:text-gray-200 
+                          hover:bg-gray-100 dark:hover:bg-gray-700
+                          focus:bg-gray-100 dark:focus:bg-gray-700
+                        "
+                        onClick={() => {
+                          router.push(`/app/finanzas/facturas-venta/${factura.id}/editar`);
+                        }}
+                      >
+                        <Pencil className="mr-2 h-4 w-4 flex-shrink-0" />
+                        <span>Editar</span>
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem 
                       className="
                         cursor-pointer text-sm

--- a/src/components/finanzas/facturas-venta/editar/EditarFacturaVenta.tsx
+++ b/src/components/finanzas/facturas-venta/editar/EditarFacturaVenta.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { FileText, ArrowLeft, AlertCircle } from 'lucide-react';
+import { supabase } from '@/lib/supabase/config';
+import { getOrganizationId } from '@/lib/hooks/useOrganization';
+import { NuevaFacturaForm } from '../nueva-factura/NuevaFacturaForm';
+import { useToast } from '@/components/ui/use-toast';
+
+interface EditarFacturaVentaProps {
+  facturaId: string;
+}
+
+export function EditarFacturaVenta({ facturaId }: EditarFacturaVentaProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [factura, setFactura] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const organizationId = getOrganizationId();
+
+  useEffect(() => {
+    cargarFactura();
+  }, [facturaId]);
+
+  const cargarFactura = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      if (!organizationId || !facturaId) {
+        setError('Faltan datos para cargar la factura.');
+        return;
+      }
+
+      const { data: facturaData, error: facturaError } = await supabase
+        .from('invoice_sales')
+        .select('*')
+        .eq('id', facturaId)
+        .eq('organization_id', organizationId)
+        .single();
+
+      if (facturaError) throw facturaError;
+      if (!facturaData) throw new Error('Factura no encontrada');
+
+      if (facturaData.status !== 'draft') {
+        setError(`No se puede editar una factura en estado "${facturaData.status}". Solo las facturas en borrador pueden editarse.`);
+        return;
+      }
+
+      const { data: itemsData, error: itemsError } = await supabase
+        .from('invoice_items')
+        .select('*')
+        .eq('invoice_sales_id', facturaId)
+        .order('id', { ascending: true });
+
+      if (itemsError) throw itemsError;
+
+      setFactura({
+        ...facturaData,
+        items: itemsData || []
+      });
+    } catch (error: any) {
+      console.error('Error cargando factura:', error);
+      setError(error.message || 'Error al cargar la factura');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (datosFactura: any) => {
+    if (!factura) return;
+
+    try {
+      setSaving(true);
+
+      const { error: updateError } = await supabase
+        .from('invoice_sales')
+        .update({
+          number: datosFactura.number,
+          customer_id: datosFactura.customer_id,
+          branch_id: datosFactura.branch_id,
+          issue_date: datosFactura.issue_date,
+          due_date: datosFactura.due_date,
+          currency: datosFactura.currency,
+          payment_terms: datosFactura.payment_terms,
+          payment_method: datosFactura.payment_method,
+          notes: datosFactura.notes,
+          tax_included: datosFactura.tax_included,
+          subtotal: datosFactura.subtotal,
+          tax_total: datosFactura.tax_total,
+          total: datosFactura.total
+        })
+        .eq('id', factura.id);
+
+      if (updateError) throw updateError;
+
+      const { data: existingItems, error: fetchItemsError } = await supabase
+        .from('invoice_items')
+        .select('id')
+        .eq('invoice_sales_id', factura.id);
+
+      if (fetchItemsError) throw fetchItemsError;
+
+      const existingIds = (existingItems || []).map(i => i.id);
+      const newItemIds = datosFactura.items.filter((i: any) => i.id).map((i: any) => i.id);
+      const idsToDelete = existingIds.filter(id => !newItemIds.includes(id));
+
+      if (idsToDelete.length > 0) {
+        const { error: deleteError } = await supabase
+          .from('invoice_items')
+          .delete()
+          .in('id', idsToDelete)
+          .eq('invoice_sales_id', factura.id);
+
+        if (deleteError) throw deleteError;
+      }
+
+      for (const item of datosFactura.items) {
+        const itemData = {
+          invoice_sales_id: factura.id,
+          product_id: item.product_id || null,
+          description: item.description,
+          qty: item.qty,
+          unit_price: item.unit_price,
+          tax_code: item.tax_code || null,
+          tax_rate: item.tax_rate || 0,
+          tax_included: item.tax_included || false,
+          total_line: item.total_line,
+          discount_amount: item.discount_amount || 0
+        };
+
+        if (item.id) {
+          const { error: updateItemError } = await supabase
+            .from('invoice_items')
+            .update(itemData)
+            .eq('id', item.id)
+            .eq('invoice_sales_id', factura.id);
+
+          if (updateItemError) throw updateItemError;
+        } else {
+          const { error: insertItemError } = await supabase
+            .from('invoice_items')
+            .insert(itemData);
+
+          if (insertItemError) throw insertItemError;
+        }
+      }
+
+      if (factura.sale_id) {
+        const { error: saleUpdateError } = await supabase
+          .from('sales')
+          .update({
+            customer_id: datosFactura.customer_id,
+            branch_id: datosFactura.branch_id,
+            subtotal: datosFactura.subtotal,
+            tax_total: datosFactura.tax_total,
+            total: datosFactura.total,
+            balance: datosFactura.total
+          })
+          .eq('id', factura.sale_id);
+
+        if (saleUpdateError) {
+          console.error('Error al actualizar venta:', saleUpdateError);
+        }
+      }
+
+      toast({
+        title: 'Factura actualizada',
+        description: 'La factura de venta se ha actualizado correctamente.',
+      });
+
+      router.push(`/app/finanzas/facturas-venta/${factura.id}`);
+    } catch (error: any) {
+      console.error('Error actualizando factura:', error);
+      toast({
+        title: 'Error al actualizar',
+        description: error.message || 'Error al actualizar la factura',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-4 mb-4 sm:mb-6">
+          <div className="flex items-center gap-2 sm:gap-3 w-full sm:w-auto">
+            <Skeleton className="h-9 w-9 rounded-lg" />
+            <Skeleton className="h-10 w-10 rounded-lg" />
+            <Skeleton className="h-8 w-64" />
+          </div>
+        </div>
+        <Card className="
+          p-3 sm:p-4 lg:p-6
+          bg-white dark:bg-gray-800
+          border-gray-200 dark:border-gray-700
+          shadow-sm
+          w-full
+          overflow-hidden
+        ">
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <Skeleton className="h-32 w-full" />
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-4 mb-4 sm:mb-6">
+          <div className="flex items-center gap-2 sm:gap-3 w-full sm:w-auto">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => router.back()}
+              className="p-2 h-auto min-w-[36px] sm:min-w-[40px] hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+            >
+              <ArrowLeft className="h-4 w-4 sm:h-5 sm:w-5 text-blue-600 dark:text-blue-400" />
+            </Button>
+            <div className="flex-shrink-0 p-2 rounded-lg bg-blue-50 dark:bg-blue-900/20">
+              <FileText className="h-5 w-5 sm:h-6 sm:w-6 text-blue-600 dark:text-blue-400" />
+            </div>
+            <h1 className="text-lg sm:text-xl lg:text-2xl font-bold text-gray-900 dark:text-gray-100 tracking-tight">
+              Editar Factura
+            </h1>
+          </div>
+        </div>
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+        <div className="text-center">
+          <p className="text-gray-500 dark:text-gray-400 mb-4">
+            {error.includes('No se puede editar') ?
+              'La factura no puede ser editada en su estado actual.' :
+              'No se pudo cargar la información de la factura.'}
+          </p>
+          <div className="flex justify-center gap-2">
+            <Button variant="default" onClick={cargarFactura}>
+              Intentar de nuevo
+            </Button>
+            <Button variant="outline" onClick={() => router.push(`/app/finanzas/facturas-venta/${facturaId}`)}>
+              Volver al detalle
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (factura) {
+    return (
+      <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-4 mb-4 sm:mb-6">
+          <div className="flex items-center gap-2 sm:gap-3 w-full sm:w-auto">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => router.back()}
+              className="
+                p-2 h-auto min-w-[36px] sm:min-w-[40px]
+                hover:bg-gray-100 dark:hover:bg-gray-700
+                rounded-lg
+                transition-colors
+              "
+            >
+              <ArrowLeft className="h-4 w-4 sm:h-5 sm:w-5 text-blue-600 dark:text-blue-400" />
+            </Button>
+            <div className="flex-shrink-0 p-2 rounded-lg bg-blue-50 dark:bg-blue-900/20">
+              <FileText className="h-5 w-5 sm:h-6 sm:w-6 text-blue-600 dark:text-blue-400" />
+            </div>
+            <h1 className="text-lg sm:text-xl lg:text-2xl font-bold text-gray-900 dark:text-gray-100 tracking-tight">
+              Editar Factura de Venta
+            </h1>
+          </div>
+        </div>
+        <Card className="
+          p-3 sm:p-4 lg:p-6
+          bg-white dark:bg-gray-800
+          border-gray-200 dark:border-gray-700
+          shadow-sm
+          w-full
+          overflow-hidden
+        ">
+          <NuevaFacturaForm
+            facturaInicial={factura}
+            onSubmit={handleSubmit}
+            saving={saving}
+            esEdicion={true}
+          />
+        </Card>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/finanzas/facturas-venta/id/DetalleFactura.tsx
+++ b/src/components/finanzas/facturas-venta/id/DetalleFactura.tsx
@@ -2,13 +2,13 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { 
-  FileText, 
-  ArrowLeft, 
-  Calendar, 
-  User, 
-  CreditCard, 
-  Receipt, 
+import {
+  FileText,
+  ArrowLeft,
+  Calendar,
+  User,
+  CreditCard,
+  Receipt,
   Info,
   FileEdit,
   FileOutput,
@@ -17,7 +17,8 @@ import {
   Send,
   Download,
   Printer,
-  Copy
+  Copy,
+  Pencil
 } from 'lucide-react';
 import { 
   Card,
@@ -523,15 +524,26 @@ export default function DetalleFactura({ factura }: { factura: any }) {
         
         <div className="flex gap-1.5 sm:gap-2 flex-wrap w-full sm:w-auto">
           {isDraft && (
-            <Button 
-              variant="default" 
-              size="sm"
-              onClick={emitirFactura}
-              className="flex items-center gap-1 h-8 px-2 sm:px-3 text-xs bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700"
-            >
-              <Send className="h-3.5 w-3.5" />
-              <span>Emitir</span>
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => router.push(`/app/finanzas/facturas-venta/${facturaActual.id}/editar`)}
+                className="flex items-center gap-1 h-8 px-2 sm:px-3 text-xs dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                <span>Editar</span>
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={emitirFactura}
+                className="flex items-center gap-1 h-8 px-2 sm:px-3 text-xs bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700"
+              >
+                <Send className="h-3.5 w-3.5" />
+                <span>Emitir</span>
+              </Button>
+            </>
           )}
           {!isDraft && (
             <Button 

--- a/src/components/finanzas/facturas-venta/nueva-factura/NuevaFacturaForm.tsx
+++ b/src/components/finanzas/facturas-venta/nueva-factura/NuevaFacturaForm.tsx
@@ -19,6 +19,7 @@ import { Save, FileCheck, ArrowLeft, RefreshCw, Coins } from 'lucide-react';
 import { DatePicker } from '@/components/ui/date-picker';
 import { ElectronicInvoiceToggle } from '@/components/finanzas/facturacion-electronica';
 import { electronicInvoicingService } from '@/lib/services/electronicInvoicingService';
+import { toLocalDateString, parseLocalDate } from '@/utils/Utils';
 
 // Tipo para un ítem de factura
 export type InvoiceItem = {
@@ -62,7 +63,14 @@ interface Invoice {
   created_by?: string; // ID del usuario que crea la factura
 };
 
-export function NuevaFacturaForm() {
+interface NuevaFacturaFormProps {
+  facturaInicial?: any;
+  onSubmit?: (datosFactura: any) => Promise<void>;
+  saving?: boolean;
+  esEdicion?: boolean;
+}
+
+export function NuevaFacturaForm({ facturaInicial, onSubmit, saving, esEdicion }: NuevaFacturaFormProps = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const organizationId = getOrganizationId();
@@ -170,8 +178,45 @@ export function NuevaFacturaForm() {
     loadCurrencies();
   }, [loadCurrencies]);
 
-  // Cargar datos de factura a duplicar
+  // Cargar datos de factura para edición
   useEffect(() => {
+    if (esEdicion && facturaInicial) {
+      setInvoiceNumber(facturaInicial.number || '');
+      setSelectedCustomerId(facturaInicial.customer_id || null);
+      setCurrency(facturaInicial.currency || 'COP');
+      setPaymentTerms(facturaInicial.payment_terms || 30);
+      setPaymentMethodCode(facturaInicial.payment_method || '');
+      setNotes(facturaInicial.notes || '');
+      setTaxIncluded(facturaInicial.tax_included || false);
+      setBranchId(facturaInicial.branch_id || getCurrentBranchIdWithFallback());
+
+      if (facturaInicial.issue_date) {
+        setIssueDate(parseLocalDate(facturaInicial.issue_date));
+      }
+      if (facturaInicial.due_date) {
+        setDueDate(parseLocalDate(facturaInicial.due_date));
+      }
+
+      // Cargar items de la factura
+      if (facturaInicial.items && facturaInicial.items.length > 0) {
+        const itemsFormateados = facturaInicial.items.map((item: any) => ({
+          id: item.id,
+          product_id: item.product_id,
+          description: item.description,
+          qty: item.qty,
+          unit_price: item.unit_price,
+          tax_code: item.tax_code,
+          tax_rate: item.tax_rate,
+          tax_included: item.tax_included || false,
+          total_line: item.total_line,
+          discount_amount: item.discount_amount || 0
+        }));
+        setItems(itemsFormateados);
+      }
+      return;
+    }
+
+    // Cargar datos de factura a duplicar
     const cargarDatosDuplicacion = async () => {
       if (!duplicarId || !organizationId) return;
       
@@ -231,12 +276,18 @@ export function NuevaFacturaForm() {
     
     setIsValidatingNumber(true);
     try {
-      const { data, error } = await supabase
+      let query = supabase
         .from('invoice_sales')
         .select('id')
         .eq('organization_id', organizationId)
-        .eq('number', number)
-        .limit(1);
+        .eq('number', number);
+      
+      // En modo edición, excluir la factura actual de la validación
+      if (esEdicion && facturaInicial?.id) {
+        query = query.neq('id', facturaInicial.id);
+      }
+      
+      const { data, error } = await query.limit(1);
         
       if (error) throw error;
       
@@ -262,13 +313,15 @@ export function NuevaFacturaForm() {
   }, [organizationId]);
 
   useEffect(() => {
-    if (organizationId) {
+    if (organizationId && !esEdicion) {
       generateInvoiceNumber();
     }
-  }, [organizationId]);
+  }, [organizationId, esEdicion]);
 
   // Efecto para validar el número de factura cuando cambia
   useEffect(() => {
+    // En modo edición, no validar automáticamente al cargar
+    if (esEdicion) return;
     // Usar un timer para no validar con cada pulsación
     const timer = setTimeout(() => {
       if (invoiceNumber && invoiceNumber.trim() !== '') {
@@ -277,7 +330,7 @@ export function NuevaFacturaForm() {
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [invoiceNumber, checkDuplicateInvoiceNumber]);
+  }, [invoiceNumber, checkDuplicateInvoiceNumber, esEdicion]);
 
   // Función para generar número de factura
   const generateInvoiceNumber = async () => {
@@ -351,12 +404,47 @@ export function NuevaFacturaForm() {
       return;
     }
     
-    // Verificar si el número de factura está duplicado antes de guardar
-    const isDuplicate = await checkDuplicateInvoiceNumber(invoiceNumber);
-    if (isDuplicate) {
-      return; // No continuar si el número está duplicado
+    // En modo edición, omitir validación de duplicado (es el mismo número)
+    if (!esEdicion) {
+      const isDuplicate = await checkDuplicateInvoiceNumber(invoiceNumber);
+      if (isDuplicate) {
+        return;
+      }
     }
-    
+
+    // Si estamos en modo edición, delegar al onSubmit del padre
+    if (esEdicion && onSubmit) {
+      const datosFactura = {
+        number: invoiceNumber,
+        customer_id: selectedCustomerId,
+        branch_id: branchId,
+        issue_date: issueDate ? toLocalDateString(issueDate) : null,
+        due_date: dueDate ? toLocalDateString(dueDate) : null,
+        currency,
+        payment_terms: paymentTerms,
+        payment_method: paymentMethodCode || null,
+        notes: notes || null,
+        tax_included: taxIncluded,
+        subtotal,
+        tax_total: taxTotal,
+        total,
+        items: items.map(item => ({
+          id: item.id,
+          product_id: item.product_id,
+          description: item.description,
+          qty: item.qty,
+          unit_price: item.unit_price,
+          tax_code: item.tax_code,
+          tax_rate: item.tax_rate,
+          tax_included: item.tax_included || false,
+          total_line: item.total_line,
+          discount_amount: item.discount_amount || 0
+        }))
+      };
+      await onSubmit(datosFactura);
+      return;
+    }
+
     try {
       setIsLoading(true);
       
@@ -416,8 +504,8 @@ export function NuevaFacturaForm() {
         customer_id: selectedCustomerId || null,
         sale_id: saleData.id, // Vinculamos con la venta creada
         number: invoiceNumber,
-        issue_date: issueDate?.toISOString().split('T')[0] || null,
-        due_date: dueDate?.toISOString().split('T')[0] || null,
+        issue_date: issueDate ? toLocalDateString(issueDate) : null,
+        due_date: dueDate ? toLocalDateString(dueDate) : null,
         currency: currency, // Moneda seleccionada por el usuario
         subtotal: subtotal,
         tax_total: taxTotal,
@@ -537,6 +625,7 @@ export function NuevaFacturaForm() {
                 if (invoiceNumber) {
                   checkDuplicateInvoiceNumber(invoiceNumber);
                 }
+                // En modo edición, resetear isDuplicateNumber si la validación pasa
               }}
               placeholder="Ej: FACT-00001"
               required
@@ -841,7 +930,7 @@ export function NuevaFacturaForm() {
         <Button
           size="sm"
           onClick={handleSaveInvoice}
-          disabled={isLoading}
+          disabled={isLoading || saving}
           className="
             w-full sm:w-auto
             bg-blue-600 hover:bg-blue-700
@@ -851,7 +940,7 @@ export function NuevaFacturaForm() {
           "
         >
           <Save className="w-4 h-4 mr-2 flex-shrink-0" />
-          <span className="text-sm">{isLoading ? 'Guardando...' : 'Guardar Factura'}</span>
+          <span className="text-sm">{(isLoading || saving) ? 'Guardando...' : esEdicion ? 'Guardar Cambios' : 'Guardar Factura'}</span>
         </Button>
       </div>
     </div>

--- a/src/components/inventario/proveedores/detalle/ProveedorDetalle.tsx
+++ b/src/components/inventario/proveedores/detalle/ProveedorDetalle.tsx
@@ -112,7 +112,7 @@ export function ProveedorDetalle({ supplierUuid }: ProveedorDetalleProps) {
   };
 
   const accountTypeLabel = (val?: string) => {
-    const map: Record<string, string> = { ahorros: 'Ahorros', corriente: 'Corriente' };
+    const map: Record<string, string> = { savings: 'Ahorros', checking: 'Corriente', other: 'Otro' };
     return val ? map[val] || val : 'No definido';
   };
 

--- a/src/components/inventario/proveedores/editar/EditarProveedorForm.tsx
+++ b/src/components/inventario/proveedores/editar/EditarProveedorForm.tsx
@@ -333,8 +333,9 @@ export function EditarProveedorForm({ supplierUuid }: EditarProveedorFormProps) 
                     <Select value={formData.account_type || ''} onValueChange={(v) => handleChange('account_type', v)}>
                       <SelectTrigger className="dark:bg-gray-900 dark:border-gray-700"><SelectValue placeholder="Seleccionar" /></SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="ahorros">Ahorros</SelectItem>
-                        <SelectItem value="corriente">Corriente</SelectItem>
+                        <SelectItem value="savings">Ahorros</SelectItem>
+                        <SelectItem value="checking">Corriente</SelectItem>
+                        <SelectItem value="other">Otro</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/src/components/inventario/proveedores/nuevo/NuevoProveedorForm.tsx
+++ b/src/components/inventario/proveedores/nuevo/NuevoProveedorForm.tsx
@@ -289,8 +289,9 @@ export function NuevoProveedorForm() {
                     <Select value={formData.account_type || ''} onValueChange={(v) => handleChange('account_type', v)}>
                       <SelectTrigger className="dark:bg-gray-900 dark:border-gray-700"><SelectValue placeholder="Seleccionar" /></SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="ahorros">Ahorros</SelectItem>
-                        <SelectItem value="corriente">Corriente</SelectItem>
+                        <SelectItem value="savings">Ahorros</SelectItem>
+                        <SelectItem value="checking">Corriente</SelectItem>
+                        <SelectItem value="other">Otro</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -13,6 +13,21 @@ export function cn(...inputs: ClassValue[]): string {
 }
 
 /**
+ * Convierte un Date a string YYYY-MM-DD usando componentes de fecha local.
+ * A diferencia de toISOString().split('T')[0], este metodo no convierte a UTC,
+ * evitando que la fecha cambie de dia segun la zona horaria del navegador.
+ *
+ * @param date - Objeto Date a convertir
+ * @returns String en formato YYYY-MM-DD
+ */
+export function toLocalDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
  * Parsea una fecha evitando el offset de zona horaria.
  * Las fechas en formato YYYY-MM-DD (sin hora) son interpretadas por new Date() como UTC medianoche,
  * lo que en zonas horarias negativas (America) muestra un dia menos.
@@ -26,6 +41,13 @@ export function parseLocalDate(dateString: string): Date {
   // Si la fecha es solo YYYY-MM-DD (sin hora), anadir T00:00:00 para evitar offset UTC
   if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
     return new Date(dateString + 'T00:00:00');
+  }
+  // Si la fecha viene con timestamp y zona horaria (ej: 2026-06-17T00:00:00+00:00),
+  // extraer solo la parte de fecha YYYY-MM-DD e interpretarla como hora local
+  // para evitar que el offset UTC desplace la fecha un dia en zonas horarias negativas
+  const dateOnly = dateString.split('T')[0];
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateOnly)) {
+    return new Date(dateOnly + 'T00:00:00');
   }
   return new Date(dateString);
 }


### PR DESCRIPTION
…fix suppliers account_type

- Editar factura de venta cuando status=draft (ruta /editar, componente EditarFacturaVenta)
- NuevaFacturaForm soporta modo edicion con props facturaInicial, onSubmit, saving, esEdicion
- Boton Editar en DetalleFactura y menu de acciones de FacturasTable cuando es borrador
- Fix: parseLocalDate ahora extrae YYYY-MM-DD de timestamps con timezone (timestamptz)
- Fix: suppliers account_type usa valores validos (savings/checking/other) no (ahorros/corriente)
- Fix: validacion de numero duplicado excluye factura actual en modo edicion
- Renombrar Branding a Sitio Web en sidebar y traducciones
- Colores dinamicos de organizacion en PDFs de factura (pdfService, api route)
- toLocalDateString para evitar offset UTC en fechas de facturas