### PR TITLE
fix: unificar status 'void' en facturas y notas crédito

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -407,7 +407,7 @@ function LoginContent() {
                   type="email"
                   autoComplete="email"
                   required
-                  className="w-full px-2 py-2 sm:py-3 text-sm sm:text-base focus:outline-none"
+                  className="w-full px-2 py-2 sm:py-3 text-sm sm:text-base focus:outline-none bg-white text-gray-900 placeholder:text-gray-400"
                   placeholder={t('emailPlaceholder')}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -427,7 +427,7 @@ function LoginContent() {
                   type={showPassword ? "text" : "password"}
                   autoComplete="current-password"
                   required
-                  className="w-full px-2 py-2 sm:py-3 text-sm sm:text-base focus:outline-none"
+                  className="w-full px-2 py-2 sm:py-3 text-sm sm:text-base focus:outline-none bg-white text-gray-900 placeholder:text-gray-400"
                   placeholder={t('passwordPlaceholder')}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}

--- a/src/components/finanzas/facturas-compra/nueva-factura/NuevaFacturaForm.tsx
+++ b/src/components/finanzas/facturas-compra/nueva-factura/NuevaFacturaForm.tsx
@@ -403,10 +403,18 @@ export function NuevaFacturaForm({
 
   // Memoizar códigos de impuestos iniciales para edición
   const initialAppliedTaxCodes = useMemo(() => {
-    if (esEdicion && facturaInicial?.applied_taxes) {
-      return facturaInicial.applied_taxes
-        .filter((t: any) => t.is_applied)
-        .map((t: any) => t.tax_code);
+    if (esEdicion && facturaInicial) {
+      // Prioridad 1: impuestos guardados en invoice_purchase_applied_taxes
+      if (facturaInicial.applied_taxes && facturaInicial.applied_taxes.length > 0) {
+        return facturaInicial.applied_taxes
+          .filter((t: any) => t.is_applied)
+          .map((t: any) => t.tax_code);
+      }
+      // Fallback para facturas viejas: usar tax_code de los items
+      if (facturaInicial.items) {
+        const taxCodes = [...new Set(facturaInicial.items.map((item: any) => item.tax_code).filter(Boolean))];
+        if (taxCodes.length > 0) return taxCodes;
+      }
     }
     return undefined;
   }, [esEdicion, facturaInicial]);

--- a/src/components/finanzas/facturas-venta/nueva-factura/NuevaFacturaForm.tsx
+++ b/src/components/finanzas/facturas-venta/nueva-factura/NuevaFacturaForm.tsx
@@ -355,10 +355,18 @@ export function NuevaFacturaForm({ facturaInicial, onSubmit, saving, esEdicion }
 
   // Memoizar códigos de impuestos iniciales para edición (evita loop infinito)
   const initialAppliedTaxCodes = useMemo(() => {
-    if (esEdicion && facturaInicial?.applied_taxes) {
-      return facturaInicial.applied_taxes
-        .filter((t: any) => t.is_applied)
-        .map((t: any) => t.tax_code);
+    if (esEdicion && facturaInicial) {
+      // Prioridad 1: impuestos guardados en invoice_applied_taxes
+      if (facturaInicial.applied_taxes && facturaInicial.applied_taxes.length > 0) {
+        return facturaInicial.applied_taxes
+          .filter((t: any) => t.is_applied)
+          .map((t: any) => t.tax_code);
+      }
+      // Fallback para facturas viejas: usar tax_code de los items
+      if (facturaInicial.items) {
+        const taxCodes = [...new Set(facturaInicial.items.map((item: any) => item.tax_code).filter(Boolean))];
+        if (taxCodes.length > 0) return taxCodes;
+      }
     }
     return undefined;
   }, [esEdicion, facturaInicial]);

--- a/src/components/finanzas/notas-credito/NotaCreditoDetalle.tsx
+++ b/src/components/finanzas/notas-credito/NotaCreditoDetalle.tsx
@@ -53,7 +53,7 @@ const statusColors: Record<string, string> = {
   sent: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
   accepted: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
   rejected: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-  voided: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  void: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
   paid: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
 };
 
@@ -63,7 +63,7 @@ const statusLabels: Record<string, string> = {
   sent: 'Enviada',
   accepted: 'Aceptada DIAN',
   rejected: 'Rechazada',
-  voided: 'Anulada',
+  void: 'Anulada',
   paid: 'Pagada',
 };
 
@@ -233,7 +233,7 @@ export function NotaCreditoDetalle({ id }: NotaCreditoDetalleProps) {
               Reintentar DIAN
             </Button>
           )}
-          {nota.status !== 'voided' && nota.status !== 'accepted' && (
+          {nota.status !== 'void' && nota.status !== 'accepted' && (
             <Button variant="destructive" onClick={handleAnular}>
               <XCircle className="h-4 w-4 mr-2" />
               Anular

--- a/src/components/finanzas/notas-credito/NotasCreditoPage.tsx
+++ b/src/components/finanzas/notas-credito/NotasCreditoPage.tsx
@@ -57,7 +57,7 @@ const statusColors: Record<string, string> = {
   sent: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
   accepted: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
   rejected: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-  voided: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  void: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
   paid: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
 };
 
@@ -67,7 +67,7 @@ const statusLabels: Record<string, string> = {
   sent: 'Enviada',
   accepted: 'Aceptada DIAN',
   rejected: 'Rechazada',
-  voided: 'Anulada',
+  void: 'Anulada',
   paid: 'Pagada',
 };
 
@@ -77,7 +77,7 @@ const statusIcons: Record<string, React.ReactNode> = {
   sent: <CheckCircle className="h-3 w-3" />,
   accepted: <CheckCircle className="h-3 w-3" />,
   rejected: <AlertCircle className="h-3 w-3" />,
-  voided: <XCircle className="h-3 w-3" />,
+  void: <XCircle className="h-3 w-3" />,
   paid: <CheckCircle className="h-3 w-3" />,
 };
 
@@ -280,7 +280,7 @@ export function NotasCreditoPage() {
             <SelectItem value="sent">Enviada</SelectItem>
             <SelectItem value="accepted">Aceptada</SelectItem>
             <SelectItem value="rejected">Rechazada</SelectItem>
-            <SelectItem value="voided">Anulada</SelectItem>
+            <SelectItem value="void">Anulada</SelectItem>
           </SelectContent>
         </Select>
         <Button variant="outline" onClick={loadData} className="dark:border-gray-700">
@@ -374,7 +374,7 @@ export function NotasCreditoPage() {
                             <Eye className="h-4 w-4 mr-2" />
                             Ver Detalle
                           </DropdownMenuItem>
-                          {nota.status !== 'voided' && nota.status !== 'accepted' && (
+                          {nota.status !== 'void' && nota.status !== 'accepted' && (
                             <>
                               <DropdownMenuSeparator className="dark:bg-gray-700" />
                               <DropdownMenuItem

--- a/src/components/reportes/finanzas/FinanzasFacturasTable.tsx
+++ b/src/components/reportes/finanzas/FinanzasFacturasTable.tsx
@@ -20,8 +20,7 @@ const statusLabels: Record<string, { label: string; class: string }> = {
   issued: { label: 'Emitida', class: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' },
   paid: { label: 'Pagada', class: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400' },
   overdue: { label: 'Vencida', class: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400' },
-  cancelled: { label: 'Anulada', class: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400' },
-  voided: { label: 'Anulada', class: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400' },
+  void: { label: 'Anulada', class: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400' },
   partial: { label: 'Parcial', class: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400' },
 };
 

--- a/src/components/reportes/finanzas/finanzasReportService.ts
+++ b/src/components/reportes/finanzas/finanzasReportService.ts
@@ -102,8 +102,8 @@ export const finanzasReportService = {
     for (const inv of invoices || []) {
       facturasEmitidas++;
       if (inv.status === 'paid') facturasPagadas++;
-      else if (inv.status === 'cancelled' || inv.status === 'voided') facturasAnuladas++;
-      if (inv.status !== 'cancelled' && inv.status !== 'voided') {
+      else if (inv.status === 'void') facturasAnuladas++;
+      if (inv.status !== 'void') {
         totalFacturado += Number(inv.total) || 0;
         totalBalance += Number(inv.balance) || 0;
       }

--- a/src/lib/services/notasCreditoService.ts
+++ b/src/lib/services/notasCreditoService.ts
@@ -216,14 +216,14 @@ class NotasCreditoService {
       return { success: false, error: 'Nota de crédito no encontrada' };
     }
 
-    if (nota.status === 'cancelled' || nota.status === 'voided') {
+    if (nota.status === 'void') {
       return { success: false, error: 'La nota de crédito ya está anulada' };
     }
 
     const { error } = await supabase
       .from('invoice_sales')
       .update({
-        status: 'voided',
+        status: 'void',
         notes: nota.notes 
           ? `${nota.notes}\n\nANULADA: ${reason || 'Sin motivo'}`
           : `ANULADA: ${reason || 'Sin motivo'}`,
@@ -234,6 +234,41 @@ class NotasCreditoService {
     if (error) {
       console.error('Error anulando nota credito:', error);
       return { success: false, error: error.message };
+    }
+
+    // Restaurar el balance de la factura original
+    if (nota.related_invoice_id) {
+      const montoNota = Math.abs(Number(nota.total));
+      const { data: facturaOriginal } = await supabase
+        .from('invoice_sales')
+        .select('id, balance, total, status')
+        .eq('id', nota.related_invoice_id)
+        .single();
+
+      if (facturaOriginal) {
+        const balanceActual = Number(facturaOriginal.balance);
+        const totalActual = Number(facturaOriginal.total);
+        const nuevoBalance = balanceActual + montoNota;
+
+        // Determinar el nuevo status de la factura original
+        let nuevoStatus = facturaOriginal.status;
+        if (nuevoBalance >= totalActual) {
+          nuevoStatus = 'issued';
+        } else if (nuevoBalance > 0) {
+          nuevoStatus = 'partial';
+        } else {
+          nuevoStatus = 'paid';
+        }
+
+        await supabase
+          .from('invoice_sales')
+          .update({
+            balance: nuevoBalance,
+            status: nuevoStatus,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', nota.related_invoice_id);
+      }
     }
 
     return { success: true };
@@ -262,7 +297,7 @@ class NotasCreditoService {
       .select('total, issue_date, status')
       .eq('organization_id', organizationId)
       .eq('document_type', 'credit_note')
-      .neq('status', 'voided');
+      .neq('status', 'void');
 
     if (error || !data) {
       return { total: 0, count: 0, thisMonth: 0, pending: 0 };

--- a/src/lib/services/reportesFinancierosService.ts
+++ b/src/lib/services/reportesFinancierosService.ts
@@ -93,7 +93,7 @@ class ReportesFinancierosService {
         .eq('organization_id', organizationId)
         .gte('issue_date', dateRange.from)
         .lte('issue_date', dateRange.to)
-        .neq('status', 'voided');
+        .neq('status', 'void');
 
       // Obtener costos (facturas de compra)
       const { data: compras } = await supabase
@@ -102,7 +102,7 @@ class ReportesFinancierosService {
         .eq('organization_id', organizationId)
         .gte('issue_date', dateRange.from)
         .lte('issue_date', dateRange.to)
-        .neq('status', 'voided');
+        .neq('status', 'void');
 
       const ingresos = ventas?.reduce((sum, v) => sum + Number(v.total || 0), 0) || 0;
       const costos = compras?.reduce((sum, c) => sum + Number(c.total || 0), 0) || 0;
@@ -241,7 +241,7 @@ class ReportesFinancierosService {
         .eq('organization_id', organizationId)
         .gte('issue_date', dateRange.from)
         .lte('issue_date', dateRange.to)
-        .neq('status', 'voided');
+        .neq('status', 'void');
 
       // IVA de compras
       const { data: compras } = await supabase
@@ -250,7 +250,7 @@ class ReportesFinancierosService {
         .eq('organization_id', organizationId)
         .gte('issue_date', dateRange.from)
         .lte('issue_date', dateRange.to)
-        .neq('status', 'voided');
+        .neq('status', 'void');
 
       const ivaRecaudado = ventas?.reduce((sum, v) => sum + Number(v.tax_total || 0), 0) || 0;
       const ivaPagado = compras?.reduce((sum, c) => sum + Number(c.tax_total || 0), 0) || 0;


### PR DESCRIPTION
- Corregir 'voided'/'cancelled' a 'void' (constraint invoice_sales_status_check)
- Anular nota crédito ahora restaura balance de factura original
- Fallback impuestos aplicados para facturas viejas sin registros
- Fix estilos inputs login (bg-white, text-gray-900)