### PR TITLE
feat(finanzas): mostrar SKU en detalles y PDFs + marcar factura como …

### DIFF
--- a/src/components/finanzas/facturas-compra/FacturasCompraService.ts
+++ b/src/components/finanzas/facturas-compra/FacturasCompraService.ts
@@ -138,7 +138,8 @@ export class FacturasCompraService {
           unit_price,
           total_line,
           tax_rate,
-          discount_amount
+          discount_amount,
+          products(id, name, sku)
         `)
         .eq('invoice_purchase_id', id);
         

--- a/src/components/finanzas/facturas-compra/id/DetalleFacturaCompra.tsx
+++ b/src/components/finanzas/facturas-compra/id/DetalleFacturaCompra.tsx
@@ -223,7 +223,8 @@ export function DetalleFacturaCompra({ facturaId }: DetalleFacturaCompraProps) {
         qty: item.qty,
         unit_price: item.unit_price,
         tax_rate: item.tax_rate,
-        total_line: item.total_line
+        total_line: item.total_line,
+        sku: item.products?.sku
       }))
     };
     PDFService.printPurchaseInvoiceHTML(pdfData);
@@ -256,7 +257,8 @@ export function DetalleFacturaCompra({ facturaId }: DetalleFacturaCompraProps) {
         qty: item.qty,
         unit_price: item.unit_price,
         tax_rate: item.tax_rate,
-        total_line: item.total_line
+        total_line: item.total_line,
+        sku: item.products?.sku
       }))
     };
     PDFService.downloadPurchaseInvoicePDF(pdfData);
@@ -587,7 +589,18 @@ export function DetalleFacturaCompra({ facturaId }: DetalleFacturaCompraProps) {
                   {factura.items?.map((item, index) => (
                     <TableRow key={item.id || index} className="dark:border-gray-800 border-b border-gray-100">
                       <TableCell className="text-xs sm:text-sm text-gray-900 dark:text-gray-300 py-2 sm:py-3">
-                        <span className="line-clamp-2">{item.description}</span>
+                        {(() => {
+                          const sku = item.products?.sku;
+                          if (sku) {
+                            return (
+                              <div className="flex flex-col">
+                                <span className="text-xs text-gray-500 dark:text-gray-400">SKU: {sku}</span>
+                                <span className="line-clamp-2">{item.description}</span>
+                              </div>
+                            );
+                          }
+                          return <span className="line-clamp-2">{item.description}</span>;
+                        })()}
                       </TableCell>
                       <TableCell className="text-xs sm:text-sm text-right text-gray-900 dark:text-gray-300 py-2 sm:py-3 whitespace-nowrap">
                         {item.qty}

--- a/src/components/finanzas/facturas-venta/id/DetalleFactura.tsx
+++ b/src/components/finanzas/facturas-venta/id/DetalleFactura.tsx
@@ -404,7 +404,8 @@ export default function DetalleFactura({ factura }: { factura: any }) {
         qty: item.qty,
         unit_price: item.unit_price,
         tax_rate: item.tax_rate,
-        total_line: item.total_line
+        total_line: item.total_line,
+        sku: item.products?.sku || item.code_reference
       })) || []
     };
 

--- a/src/components/finanzas/facturas-venta/id/ItemsDetalle.tsx
+++ b/src/components/finanzas/facturas-venta/id/ItemsDetalle.tsx
@@ -15,6 +15,12 @@ interface Item {
   tax_included?: boolean;
   total_line: number;
   discount_amount?: number | null;
+  code_reference?: string | null;
+  products?: {
+    id: number;
+    name: string;
+    sku?: string;
+  };
   taxes?: {
     name: string;
     rate: number;
@@ -22,12 +28,20 @@ interface Item {
   };
 }
 
+interface OrganizationTax {
+  id: string;
+  name: string;
+  rate: number;
+  is_default?: boolean;
+}
+
 interface ItemsDetalleProps {
   items: Item[];
   taxIncluded?: boolean;
+  organizationTaxes?: OrganizationTax[];
 }
 
-export function ItemsDetalle({ items, taxIncluded = false }: ItemsDetalleProps) {
+export function ItemsDetalle({ items, taxIncluded = false, organizationTaxes = [] }: ItemsDetalleProps) {
   if (!items || items.length === 0) {
     return (
       <div className="text-center py-6 sm:py-8 text-sm sm:text-base text-gray-500 dark:text-gray-400">
@@ -35,6 +49,20 @@ export function ItemsDetalle({ items, taxIncluded = false }: ItemsDetalleProps) 
       </div>
     );
   }
+
+  const resolveTaxName = (item: Item): string => {
+    if (item.taxes?.name) return item.taxes.name;
+    if (item.tax_code) {
+      const found = organizationTaxes.find(t => t.id === item.tax_code || t.name === item.tax_code);
+      if (found) return found.name;
+    }
+    const rate = Number(item.tax_rate);
+    if (!isNaN(rate) && rate > 0) {
+      const found = organizationTaxes.find(t => Number(t.rate) === rate);
+      if (found) return found.name;
+    }
+    return 'Impuesto';
+  };
 
   return (
     <div className="overflow-x-auto -mx-2 sm:mx-0">
@@ -56,22 +84,41 @@ export function ItemsDetalle({ items, taxIncluded = false }: ItemsDetalleProps) 
                 <TableCell className="font-medium text-xs sm:text-sm text-gray-900 dark:text-gray-100 py-2 sm:py-3">{index + 1}</TableCell>
                 <TableCell className="text-xs sm:text-sm text-gray-900 dark:text-gray-100 py-2 sm:py-3">
                   <div className="max-w-[200px] sm:max-w-none">
-                    {item.description}
+                    {(() => {
+                      const sku = item.products?.sku || item.code_reference;
+                      if (sku) {
+                        return (
+                          <div className="flex flex-col">
+                            <span className="text-xs text-gray-500 dark:text-gray-400">SKU: {sku}</span>
+                            <span className="line-clamp-2">{item.description}</span>
+                          </div>
+                        );
+                      }
+                      return <span className="line-clamp-2">{item.description}</span>;
+                    })()}
                   </div>
                 </TableCell>
-                <TableCell className="text-right text-xs sm:text-sm text-gray-900 dark:text-gray-100 py-2 sm:py-3">{item.qty.toLocaleString()}</TableCell>
+                <TableCell className="text-right text-xs sm:text-sm text-gray-900 dark:text-gray-100 py-2 sm:py-3">{Number(item.qty).toLocaleString()}</TableCell>
                 <TableCell className="text-right text-xs sm:text-sm text-gray-900 dark:text-gray-100 py-2 sm:py-3 hidden sm:table-cell">{formatCurrency(item.unit_price)}</TableCell>
                 <TableCell className="text-right text-xs sm:text-sm py-2 sm:py-3 hidden md:table-cell">
-                  {item.tax_rate ? (
-                    <div className="flex flex-col items-end">
-                      <span className="text-gray-900 dark:text-gray-100">{item.taxes?.name || `${item.tax_code}`}</span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
-                        ({item.tax_rate.toFixed(2)}%)
-                      </span>
-                    </div>
-                  ) : (
-                    <span className="text-gray-500 dark:text-gray-400">N/A</span>
-                  )}
+                  {(() => {
+                    const rate = Number(item.tax_rate);
+                    const hasTaxCode = item.tax_code != null && item.tax_code !== '';
+                    if (hasTaxCode && !isNaN(rate) && rate > 0) {
+                      const taxName = resolveTaxName(item);
+                      const isIncluded = item.tax_included ?? taxIncluded;
+                      const nameHasRate = /\d+/.test(taxName);
+                      return (
+                        <div className="flex flex-col items-end">
+                          <span className="text-gray-700 dark:text-gray-200">{taxName}</span>
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                            {nameHasRate ? (isIncluded ? 'Incluido' : 'Adicional') : `${rate.toFixed(2)}% ${isIncluded ? '(incl.)' : '(+imp.)'}`}
+                          </span>
+                        </div>
+                      );
+                    }
+                    return <span className="text-gray-400 dark:text-gray-500">N/A</span>;
+                  })()}
                 </TableCell>
                 <TableCell className="text-right font-medium text-xs sm:text-sm text-gray-900 dark:text-gray-100 py-2 sm:py-3">
                   {formatCurrency(item.total_line)}
@@ -82,9 +129,13 @@ export function ItemsDetalle({ items, taxIncluded = false }: ItemsDetalleProps) 
         </Table>
       </div>
       
-      {taxIncluded && (
+      {taxIncluded ? (
         <div className="mt-2 sm:mt-3 text-right text-xs sm:text-sm text-gray-500 dark:text-gray-400 italic px-2 sm:px-0">
           * Los precios incluyen impuestos
+        </div>
+      ) : (
+        <div className="mt-2 sm:mt-3 text-right text-xs sm:text-sm text-gray-500 dark:text-gray-400 italic px-2 sm:px-0">
+          * Los impuestos se calculan sobre el subtotal
         </div>
       )}
     </div>

--- a/src/components/finanzas/facturas-venta/id/NotaCreditoDialog.tsx
+++ b/src/components/finanzas/facturas-venta/id/NotaCreditoDialog.tsx
@@ -102,18 +102,25 @@ export function NotaCreditoDialog({ open, onOpenChange, factura, items, onSucces
 
   // Actualizar monto total cuando cambian las selecciones o cantidades
   useEffect(() => {
+    const facturaSubtotal = Math.abs(Number(factura.subtotal) || 0);
+    const facturaTaxTotal = Math.abs(Number(factura.tax_total) || 0);
+    const tasaEfectiva = facturaSubtotal > 0 ? (facturaTaxTotal / facturaSubtotal) * 100 : 0;
+
     let total = 0;
     
     items.forEach(item => {
       if (itemsSeleccionados[item.id]) {
         const cantidad = Math.min(cantidades[item.id] || 0, item.qty);
         const precioUnitario = item.unit_price || 0;
-        total += cantidad * precioUnitario;
+        const lineaTotal = cantidad * precioUnitario;
+        const impuestoTasa = item.tax_rate != null ? Number(item.tax_rate) : tasaEfectiva;
+        const impuestoMonto = (lineaTotal * impuestoTasa) / 100;
+        total += lineaTotal + impuestoMonto;
       }
     });
     
     setMontoTotal(total);
-  }, [itemsSeleccionados, cantidades, items]);
+  }, [itemsSeleccionados, cantidades, items, factura]);
 
   // Manejar cambio en la selección de un item
   const handleItemToggle = (itemId: string, checked: boolean) => {
@@ -238,6 +245,7 @@ export function NotaCreditoDialog({ open, onOpenChange, factura, items, onSucces
       const currentUserId = user?.id;
 
       // 2. Crear la nota de crédito (es una factura con tipo credit_note)
+      const taxIncluded = factura.tax_included || false;
       const { data: creditNoteData, error: creditNoteError } = await supabase
         .from('invoice_sales')
         .insert({
@@ -248,11 +256,12 @@ export function NotaCreditoDialog({ open, onOpenChange, factura, items, onSucces
           issue_date: new Date().toISOString(),
           due_date: new Date().toISOString(),
           currency: factura.currency || 'COP',
-          subtotal: -montoTotal,  // Negativo para nota de crédito
+          subtotal: -montoTotal,  // Se actualizará después con el desglose correcto
           tax_total: 0,  // Se calculará después
           total: -montoTotal,  // Negativo para nota de crédito
           balance: 0,  // Notas de crédito comienzan en 0 porque se aplican directamente
           status: 'issued',
+          tax_included: taxIncluded, // Heredar de factura original
           description: `Nota de crédito para factura ${factura.number}. Motivo: ${motivo}`,
           related_invoice_id: factura.id,
           document_type: 'credit_note',
@@ -274,21 +283,41 @@ export function NotaCreditoDialog({ open, onOpenChange, factura, items, onSucces
       const itemsNotaCredito = [];
       let subtotal = 0;
       let taxTotal = 0;
-      
+
+      // Calcular tasa efectiva de impuesto de la factura original
+      const facturaSubtotal = Math.abs(Number(factura.subtotal) || 0);
+      const facturaTaxTotal = Math.abs(Number(factura.tax_total) || 0);
+      const tasaEfectiva = facturaSubtotal > 0 ? (facturaTaxTotal / facturaSubtotal) * 100 : 0;
+
       for (const itemId of Object.keys(itemsSeleccionados)) {
         if (itemsSeleccionados[itemId] && cantidades[itemId] > 0) {
           const item = items.find(i => i.id === itemId);
           if (item) {
             const cantidad = cantidades[itemId];
             const precioUnitario = item.unit_price || 0;
-            const impuestoTasa = item.tax_rate || 0;
+            // Usar tax_rate del item si existe, si no, usar tasa efectiva de la factura
+            const impuestoTasa = item.tax_rate != null ? Number(item.tax_rate) : tasaEfectiva;
             const lineaTotal = cantidad * precioUnitario;
-            
-            const impuestoMonto = (lineaTotal * impuestoTasa) / 100;
-            
+
+            let baseImponible = lineaTotal;
+            let impuestoMonto = 0;
+
+            if (taxIncluded && impuestoTasa > 0) {
+              // Precios con impuesto incluido: extraer la base del precio total
+              baseImponible = lineaTotal / (1 + impuestoTasa / 100);
+              baseImponible = Math.round(baseImponible * 100) / 100;
+              impuestoMonto = lineaTotal - baseImponible;
+            } else if (!taxIncluded && impuestoTasa > 0) {
+              // Precios sin impuesto: calcular impuesto sobre la base
+              impuestoMonto = (lineaTotal * impuestoTasa) / 100;
+              impuestoMonto = Math.round(impuestoMonto * 100) / 100;
+            }
+
+            const totalLinea = taxIncluded ? lineaTotal : (lineaTotal + impuestoMonto);
+
             itemsNotaCredito.push({
-              invoice_id: notaCreditoId, // Campo obligatorio NOT NULL
-              invoice_sales_id: notaCreditoId, // Campo para política RLS
+              invoice_id: notaCreditoId,
+              invoice_sales_id: notaCreditoId,
               invoice_type: 'sale',
               product_id: item.product_id,
               description: item.description,
@@ -296,12 +325,12 @@ export function NotaCreditoDialog({ open, onOpenChange, factura, items, onSucces
               unit_price: precioUnitario,
               tax_code: item.tax_code,
               tax_rate: impuestoTasa,
-              tax_included: item.tax_included || false,
-              total_line: -lineaTotal, // Negativo para nota de crédito
+              tax_included: taxIncluded,
+              total_line: -totalLinea, // Negativo
               discount_amount: item.discount_amount || 0
             });
-            
-            subtotal += lineaTotal;
+
+            subtotal += baseImponible;
             taxTotal += impuestoMonto;
           }
         }
@@ -327,9 +356,27 @@ export function NotaCreditoDialog({ open, onOpenChange, factura, items, onSucces
         
       if (updateError) throw updateError;
       
+      // 3.5 Copiar impuestos aplicados de la factura original a la nota crédito
+      const { data: originalAppliedTaxes } = await supabase
+        .from('invoice_applied_taxes')
+        .select('tax_code, is_applied')
+        .eq('invoice_id', factura.id);
+
+      if (originalAppliedTaxes && originalAppliedTaxes.length > 0) {
+        const appliedTaxesNota = originalAppliedTaxes.map(t => ({
+          invoice_id: notaCreditoId,
+          tax_code: t.tax_code,
+          is_applied: t.is_applied,
+        }));
+        const { error: taxError } = await supabase
+          .from('invoice_applied_taxes')
+          .insert(appliedTaxesNota);
+        if (taxError) console.error('Error al copiar impuestos aplicados:', taxError);
+      }
+      
       // 4. Actualizar saldo de la factura original
       const nuevoSaldo = Math.max(0, factura.balance - (subtotal + taxTotal));
-      const nuevoEstado = nuevoSaldo <= 0 ? 'paid' : nuevoSaldo < factura.total ? 'partial' : factura.status;
+      const nuevoEstado = nuevoSaldo <= 0 ? 'void' : nuevoSaldo < factura.total ? 'partial' : factura.status;
       
       const { error: facturaUpdateError } = await supabase
         .from('invoice_sales')

--- a/src/components/finanzas/notas-credito/NotaCreditoDetalle.tsx
+++ b/src/components/finanzas/notas-credito/NotaCreditoDetalle.tsx
@@ -26,22 +26,17 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { ItemsDetalle } from '@/components/finanzas/facturas-venta/id/ItemsDetalle';
 import { toast } from '@/components/ui/use-toast';
 import { formatCurrency, formatDate } from '@/utils/Utils';
-import { 
-  notasCreditoService, 
-  NotaCredito, 
+import {
+  notasCreditoService,
+  NotaCredito,
   EInvoiceJob,
-  EInvoiceEvent 
+  EInvoiceEvent
 } from '@/lib/services/notasCreditoService';
+import { supabase } from '@/lib/supabase/config';
+import { getOrganizationId } from '@/lib/hooks/useOrganization';
 
 interface NotaCreditoDetalleProps {
   id: string;
@@ -92,6 +87,7 @@ export function NotaCreditoDetalle({ id }: NotaCreditoDetalleProps) {
   const [eInvoiceEvents, setEInvoiceEvents] = useState<EInvoiceEvent[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRetrying, setIsRetrying] = useState(false);
+  const [organizationTaxes, setOrganizationTaxes] = useState<{ id: string; name: string; rate: number; is_default?: boolean }[]>([]);
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -106,6 +102,17 @@ export function NotaCreditoDetalle({ id }: NotaCreditoDetalleProps) {
         if (job) {
           const events = await notasCreditoService.getEInvoiceEvents(job.id);
           setEInvoiceEvents(events);
+        }
+
+        // Cargar impuestos de la organización para resolver nombres
+        const orgId = getOrganizationId();
+        if (orgId) {
+          const { data: taxes } = await supabase
+            .from('organization_taxes')
+            .select('id, name, rate, is_default')
+            .eq('organization_id', orgId)
+            .eq('is_active', true);
+          if (taxes) setOrganizationTaxes(taxes);
         }
       }
     } catch (error) {
@@ -265,7 +272,7 @@ export function NotaCreditoDetalle({ id }: NotaCreditoDetalleProps) {
                   <div className="text-right">
                     <p className="text-sm text-gray-500 dark:text-gray-400">Total Factura</p>
                     <p className="font-semibold text-gray-900 dark:text-white">
-                      {formatCurrency(nota.related_invoice.total)}
+                      {formatCurrency(Number(nota.related_invoice.total))}
                     </p>
                   </div>
                   <Link href={`/app/finanzas/facturas-venta/${nota.related_invoice_id}`}>
@@ -287,62 +294,64 @@ export function NotaCreditoDetalle({ id }: NotaCreditoDetalleProps) {
                 Detalle de Items
               </CardTitle>
             </CardHeader>
-            <CardContent className="p-0">
-              <Table>
-                <TableHeader>
-                  <TableRow className="dark:border-gray-700">
-                    <TableHead className="dark:text-gray-400">Descripción</TableHead>
-                    <TableHead className="dark:text-gray-400 text-right">Cant.</TableHead>
-                    <TableHead className="dark:text-gray-400 text-right">Precio</TableHead>
-                    <TableHead className="dark:text-gray-400 text-right">IVA</TableHead>
-                    <TableHead className="dark:text-gray-400 text-right">Total</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {nota.items && nota.items.length > 0 ? (
-                    nota.items.map((item) => (
-                      <TableRow key={item.id} className="dark:border-gray-700">
-                        <TableCell className="text-gray-900 dark:text-white">
-                          {item.description}
-                        </TableCell>
-                        <TableCell className="text-right text-gray-600 dark:text-gray-300">
-                          {item.quantity}
-                        </TableCell>
-                        <TableCell className="text-right text-gray-600 dark:text-gray-300">
-                          {formatCurrency(item.unit_price)}
-                        </TableCell>
-                        <TableCell className="text-right text-gray-600 dark:text-gray-300">
-                          {formatCurrency(item.tax_amount)}
-                        </TableCell>
-                        <TableCell className="text-right font-medium text-gray-900 dark:text-white">
-                          {formatCurrency(item.total)}
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  ) : (
-                    <TableRow>
-                      <TableCell colSpan={5} className="text-center py-4 text-gray-500 dark:text-gray-400">
-                        No hay items
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
+            <CardContent className="pt-0">
+              <ItemsDetalle items={nota.items || []} taxIncluded={nota.tax_included || false} organizationTaxes={organizationTaxes} />
 
               {/* Totals */}
-              <div className="border-t dark:border-gray-700 p-4 space-y-2">
+              <div className="border-t dark:border-gray-700 p-4 space-y-2 mt-4">
                 <div className="flex justify-between text-gray-600 dark:text-gray-300">
                   <span>Subtotal</span>
-                  <span>{formatCurrency(nota.subtotal)}</span>
+                  <span>{formatCurrency(Number(nota.subtotal))}</span>
                 </div>
-                <div className="flex justify-between text-gray-600 dark:text-gray-300">
-                  <span>IVA</span>
-                  <span>{formatCurrency(nota.tax_total)}</span>
-                </div>
+                {(() => {
+                  const taxTotal = Number(nota.tax_total) || 0;
+                  if (taxTotal === 0) return null;
+
+                  // Agrupar impuestos por tasa desde los items
+                  const taxGroups: Record<string, { rate: number; amount: number; name: string }> = {};
+                  (nota.items || []).forEach(item => {
+                    const rate = Number(item.tax_rate) || 0;
+                    if (rate <= 0) return;
+                    const key = rate.toString();
+                    if (!taxGroups[key]) {
+                      const orgTax = organizationTaxes.find(t => Number(t.rate) === rate);
+                      taxGroups[key] = { rate, amount: 0, name: orgTax?.name || `Impuesto ${rate}%` };
+                    }
+                    // Calcular monto del impuesto de este item
+                    const lineTotal = Math.abs(Number(item.total_line) || 0);
+                    const isIncluded = item.tax_included ?? nota.tax_included;
+                    if (isIncluded) {
+                      taxGroups[key].amount += lineTotal - (lineTotal / (1 + rate / 100));
+                    } else {
+                      taxGroups[key].amount += (lineTotal * rate) / 100;
+                    }
+                  });
+
+                  const groups = Object.values(taxGroups);
+                  if (groups.length === 0) {
+                    return (
+                      <div className="flex justify-between text-gray-600 dark:text-gray-300">
+                        <span>Impuestos {nota.tax_included ? '(incluidos)' : '(adicionales)'}</span>
+                        <span>{formatCurrency(taxTotal)}</span>
+                      </div>
+                    );
+                  }
+
+                  return (
+                    <div className="space-y-1">
+                      {groups.map(g => (
+                        <div key={g.rate} className="flex justify-between text-gray-600 dark:text-gray-300">
+                          <span>{g.name} {nota.tax_included ? '(incl.)' : '(+imp.)'}</span>
+                          <span>-{formatCurrency(g.amount)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })()}
                 <Separator className="dark:bg-gray-700" />
                 <div className="flex justify-between text-lg font-bold text-red-600 dark:text-red-400">
                   <span>Total Nota Crédito</span>
-                  <span>-{formatCurrency(nota.total)}</span>
+                  <span>{formatCurrency(Number(nota.total))}</span>
                 </div>
               </div>
             </CardContent>
@@ -484,7 +493,7 @@ export function NotaCreditoDetalle({ id }: NotaCreditoDetalleProps) {
             <CardContent className="pt-6">
               <p className="text-red-100 text-sm">Total Nota Crédito</p>
               <p className="text-3xl font-bold mt-1">
-                -{formatCurrency(nota.total)}
+                {formatCurrency(Number(nota.total))}
               </p>
               <p className="text-red-100 text-sm mt-2">
                 {formatDate(nota.issue_date)}

--- a/src/components/finanzas/notas-credito/NotasCreditoPage.tsx
+++ b/src/components/finanzas/notas-credito/NotasCreditoPage.tsx
@@ -351,7 +351,7 @@ export function NotasCreditoPage() {
                       )}
                     </TableCell>
                     <TableCell className="text-right font-semibold text-red-600 dark:text-red-400">
-                      -{formatCurrency(nota.total)}
+                      {formatCurrency(Number(nota.total))}
                     </TableCell>
                     <TableCell>
                       <Badge className={`${statusColors[nota.status]} flex items-center gap-1 w-fit`}>

--- a/src/lib/services/notasCreditoService.ts
+++ b/src/lib/services/notasCreditoService.ts
@@ -36,21 +36,29 @@ export interface NotaCredito {
     id: string;
     number: string;
     total: number;
+    subtotal?: number;
+    tax_total?: number;
+    issue_date?: string;
+    status?: string;
+    applied_taxes?: { tax_code: string; is_applied: boolean }[];
   };
   items?: NotaCreditoItem[];
+  applied_taxes?: { tax_code: string; is_applied: boolean }[];
+  tax_included?: boolean;
 }
 
 export interface NotaCreditoItem {
   id: string;
   invoice_id: string;
-  product_id?: string;
+  product_id?: number | null;
   description: string;
-  quantity: number;
+  qty: number;
   unit_price: number;
-  tax_rate: number;
-  tax_amount: number;
-  subtotal: number;
-  total: number;
+  tax_code?: string | null;
+  tax_rate?: number | null;
+  tax_included?: boolean;
+  total_line: number;
+  discount_amount?: number | null;
 }
 
 export interface EInvoiceJob {
@@ -117,7 +125,27 @@ class NotasCreditoService {
       return [];
     }
 
-    return data || [];
+    if (!data || data.length === 0) return [];
+
+    // Cargar facturas relacionadas (auto-referencia, no se puede con JOIN anidado)
+    const relatedIds = data.map(n => n.related_invoice_id).filter(Boolean);
+    if (relatedIds.length > 0) {
+      const { data: relatedInvoices } = await supabase
+        .from('invoice_sales')
+        .select('id, number, total, issue_date, status')
+        .in('id', relatedIds);
+
+      if (relatedInvoices) {
+        const invoiceMap = new Map(relatedInvoices.map(inv => [inv.id, inv]));
+        data.forEach(nota => {
+          if (nota.related_invoice_id && invoiceMap.has(nota.related_invoice_id)) {
+            nota.related_invoice = invoiceMap.get(nota.related_invoice_id);
+          }
+        });
+      }
+    }
+
+    return data;
   }
 
   /**
@@ -147,20 +175,38 @@ class NotasCreditoService {
     if (data) {
       const { data: items } = await supabase
         .from('invoice_items')
-        .select('*')
+        .select('*, products(id, name, sku)')
         .eq('invoice_id', id);
       
       data.items = items || [];
+
+      // Obtener impuestos aplicados a la nota crédito
+      const { data: appliedTaxes } = await supabase
+        .from('invoice_applied_taxes')
+        .select('tax_code, is_applied')
+        .eq('invoice_id', id);
+      
+      data.applied_taxes = appliedTaxes || [];
 
       // Obtener factura relacionada si existe
       if (data.related_invoice_id) {
         const { data: relatedInvoice } = await supabase
           .from('invoice_sales')
-          .select('id, number, total, issue_date, status')
+          .select('id, number, total, subtotal, tax_total, issue_date, status')
           .eq('id', data.related_invoice_id)
           .single();
         
         data.related_invoice = relatedInvoice || null;
+
+        // Obtener impuestos aplicados a la factura original
+        if (relatedInvoice) {
+          const { data: originalAppliedTaxes } = await supabase
+            .from('invoice_applied_taxes')
+            .select('tax_code, is_applied')
+            .eq('invoice_id', data.related_invoice_id);
+          
+          data.related_invoice.applied_taxes = originalAppliedTaxes || [];
+        }
       }
     }
 

--- a/src/lib/services/pdfService.ts
+++ b/src/lib/services/pdfService.ts
@@ -37,6 +37,7 @@ export interface InvoiceDataForPDF {
     unit_price: number;
     tax_rate?: number;
     total_line: number;
+    sku?: string;
   }[];
 }
 
@@ -230,7 +231,7 @@ export class PDFService {
             <tbody>
               ${data.items.map(item => `
                 <tr>
-                  <td>${item.description}</td>
+                  <td>${item.sku ? `<span style="color:#6b7280;font-size:11px;">SKU: ${item.sku}</span><br/>` : ''}${item.description}</td>
                   <td>${item.qty}</td>
                   <td>${formatCurrency(item.unit_price)}</td>
                   <td>${item.tax_rate ? `${item.tax_rate}%` : '-'}</td>
@@ -425,7 +426,7 @@ export class PDFService {
             <tbody>
               ${data.items.map(item => `
                 <tr>
-                  <td>${item.description}</td>
+                  <td>${item.sku ? `<span style="color:#6b7280;font-size:11px;">SKU: ${item.sku}</span><br/>` : ''}${item.description}</td>
                   <td>${item.qty}</td>
                   <td>${formatCurrency(item.unit_price)}</td>
                   <td>${item.tax_rate ? `${item.tax_rate}%` : '-'}</td>

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -61,19 +61,25 @@ export function parseLocalDate(dateString: string): Date {
  */
 // Esta función queda obsoleta y solo redirige al servicio
 // Se mantiene por compatibilidad con el código existente
-export function formatCurrency(value: number, currency: string = "COP"): string {
-  // Importar el servicio causaría un error de dependencia circular
-  // así que implementamos el formato aquí
+export function formatCurrency(value: number | string | null | undefined, currency: string = "COP"): string {
+  const num = Number(value);
+  if (isNaN(num) || value === null || value === undefined) {
+    return new Intl.NumberFormat("es-CO", {
+      style: "currency",
+      currency: currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    }).format(0);
+  }
   try {
     return new Intl.NumberFormat("es-CO", {
       style: "currency",
       currency: currency,
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
-    }).format(value);
+    }).format(num);
   } catch (error) {
-    // Si hay error con el formato (ej: moneda inválida), usar formato simple
-    return `${currency} ${value.toFixed(2)}`;
+    return `${currency} ${num.toFixed(2)}`;
   }
 }
 


### PR DESCRIPTION
…void al anular con nota crédito

- ItemsDetalle: mostrar SKU del producto junto a la descripcion
- NotaCreditoDetalle: desglose de impuestos agrupado por tasa
- ItemsDetalle: mostrar N/A cuando producto no tiene impuesto individual
- pdfService: agregar SKU en HTML de factura de venta y compra
- FacturasCompraService: traer products(sku) en query de items
- notasCreditoService: traer products(sku) en query de items
- DetalleFacturaCompra: mostrar SKU en tabla y pasar a PDF
- DetalleFactura: pasar SKU al generar PDF
- NotaCreditoDialog: marcar factura como void cuando nota credito cubre el 100%