### PR TITLE
fix: corregir conteo de pedidos web, ingresos inflados y layout móvil…

### DIFF
--- a/src/app/app/pos/pedidos-online/page.tsx
+++ b/src/app/app/pos/pedidos-online/page.tsx
@@ -90,6 +90,14 @@ export default function PedidosOnlinePage() {
     total_revenue: 0,
     avg_order_value: 0,
   });
+  const [previousStats, setPreviousStats] = useState({
+    total_orders: 0,
+    pending_orders: 0,
+    completed_orders: 0,
+    cancelled_orders: 0,
+    total_revenue: 0,
+    avg_order_value: 0,
+  });
   const [loading, setLoading] = useState(true);
   const [filters, setFilters] = useState<LocalFilters>({});
   const [soundEnabled, setSoundEnabled] = useState(true);
@@ -146,16 +154,63 @@ export default function PedidosOnlinePage() {
     }
   }, [datePreset, customDateFrom, customDateTo]);
 
+  // Rango del período ANTERIOR equivalente "a la misma hora" para comparar
+  const getComparisonRange = useCallback((): { from?: string; to?: string } => {
+    const now = new Date();
+    const startOfDay = (d: Date) => { const c = new Date(d); c.setHours(0,0,0,0); return c; };
+    const endOfDay = (d: Date) => { const c = new Date(d); c.setHours(23,59,59,999); return c; };
+    // Desplaza una fecha N días hacia atrás conservando la hora
+    const shiftDays = (d: Date, days: number) => { const c = new Date(d); c.setDate(c.getDate() - days); return c; };
+    switch (datePreset) {
+      case 'today': {
+        // Ayer desde las 00:00 hasta la misma hora actual
+        const prevStart = startOfDay(shiftDays(now, 1));
+        const prevTo = shiftDays(now, 1);
+        return { from: prevStart.toISOString(), to: prevTo.toISOString() };
+      }
+      case 'yesterday': {
+        // Antier completo (ayer ya es un día cerrado)
+        const db = shiftDays(now, 2);
+        return { from: startOfDay(db).toISOString(), to: endOfDay(db).toISOString() };
+      }
+      case 'last7': {
+        // Los 7 días anteriores al rango actual, hasta el mismo instante
+        const prevTo = shiftDays(now, 7);
+        const prevFrom = startOfDay(shiftDays(now, 14));
+        return { from: prevFrom.toISOString(), to: prevTo.toISOString() };
+      }
+      case 'last30': {
+        const prevTo = shiftDays(now, 30);
+        const prevFrom = startOfDay(shiftDays(now, 60));
+        return { from: prevFrom.toISOString(), to: prevTo.toISOString() };
+      }
+      case 'custom': {
+        if (!customDateFrom || !customDateTo) return {};
+        const from = new Date(customDateFrom + 'T00:00:00');
+        const to = new Date(customDateTo + 'T23:59:59');
+        const duration = to.getTime() - from.getTime();
+        const prevTo = new Date(from.getTime() - 1);
+        const prevFrom = new Date(from.getTime() - duration - 1);
+        return { from: prevFrom.toISOString(), to: prevTo.toISOString() };
+      }
+      default:
+        return {};
+    }
+  }, [datePreset, customDateFrom, customDateTo]);
+
   const loadOrders = useCallback(async () => {
     try {
       const dateRange = getDateRange();
+      const comparisonRange = getComparisonRange();
       const mergedFilters = { ...filters, date_from: dateRange.from, date_to: dateRange.to };
-      const [ordersData, statsData] = await Promise.all([
+      const [ordersData, statsData, prevStatsData] = await Promise.all([
         webOrdersService.getOrders(mergedFilters),
-        webOrdersService.getOrderStats(dateRange.from, dateRange.to)
+        webOrdersService.getOrderStats(dateRange.from, dateRange.to),
+        webOrdersService.getOrderStats(comparisonRange.from, comparisonRange.to)
       ]);
       setOrders(ordersData);
       setStats(statsData);
+      setPreviousStats(prevStatsData);
       setCurrentPage(1);
     } catch (error) {
       console.error('Error loading orders:', error);
@@ -167,7 +222,7 @@ export default function PedidosOnlinePage() {
     } finally {
       setLoading(false);
     }
-  }, [filters, getDateRange, toast]);
+  }, [filters, getDateRange, getComparisonRange, toast]);
 
   useEffect(() => {
     loadOrders();
@@ -593,7 +648,7 @@ export default function PedidosOnlinePage() {
       </div>
 
       {/* Estadísticas */}
-      <WebOrderStats stats={stats} isLoading={loading} datePreset={datePreset} />
+      <WebOrderStats stats={stats} previousStats={previousStats} isLoading={loading} datePreset={datePreset} />
 
       {/* Filtro de fechas */}
       <Card className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,4 +36,11 @@ body {
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
+
+  /* Altura de viewport dinámica: evita que el header se salga en iOS Safari
+     cuando la barra de herramientas del navegador aparece/desaparece al hacer scroll. */
+  .h-dynamic-screen {
+    height: 100vh; /* fallback navegadores sin soporte de dvh */
+    height: 100dvh;
+  }
 }

--- a/src/components/app-layout/AppLayout.tsx
+++ b/src/components/app-layout/AppLayout.tsx
@@ -957,7 +957,7 @@ export const AppLayout = ({
       {/* Barra de progreso de navegación - feedback visual inmediato */}
       <NavigationProgress />
       
-      <div className="flex h-screen overflow-hidden">
+      <div className="flex h-dynamic-screen overflow-hidden">
       {/* Overlay oscuro para móvil cuando el sidebar está abierto */}
       {sidebarOpen && (
         <div 
@@ -975,7 +975,7 @@ export const AppLayout = ({
         transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} 
         lg:translate-x-0 transition-transform duration-300 ease-in-out
         bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-2xl lg:shadow-lg
-        h-screen overflow-hidden
+        h-dynamic-screen overflow-hidden
       `}>
         <div className="flex flex-col h-full overflow-hidden">
           {/* Logo y nombre */}
@@ -1096,7 +1096,7 @@ export const AppLayout = ({
       )}
       
       {/* Área de contenido principal */}
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex-1 flex flex-col overflow-hidden min-w-0">
         {/* Header del panel de administración */}
         <AppHeader 
           theme={nextTheme === 'dark' ? 'dark' : 'light'}
@@ -1111,8 +1111,8 @@ export const AppLayout = ({
         />
         
         {/* Contenido principal con scroll */}
-        <div className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 overscroll-contain">
-          <div className="h-full">
+        <div className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 overscroll-contain min-w-0">
+          <div className="h-full min-w-0 w-full">
             {children}
           </div>
         </div>

--- a/src/components/pos/pedidos-online/WebOrderStats.tsx
+++ b/src/components/pos/pedidos-online/WebOrderStats.tsx
@@ -7,7 +7,9 @@ import {
   XCircle, 
   DollarSign,
   TrendingUp,
-  Package
+  Package,
+  ArrowUp,
+  ArrowDown
 } from 'lucide-react';
 
 type DatePreset = 'today' | 'yesterday' | 'last7' | 'last30' | 'custom';
@@ -20,30 +22,80 @@ const DATE_PRESET_LABELS: Record<DatePreset, string> = {
   custom: 'Total pedidos',
 };
 
+const COMPARISON_LABELS: Record<DatePreset, string> = {
+  today: 'vs ayer (misma hora)',
+  yesterday: 'vs antier',
+  last7: 'vs 7 días previos',
+  last30: 'vs 30 días previos',
+  custom: 'vs período previo',
+};
+
+interface WebOrderStatsData {
+  total_orders: number;
+  pending_orders: number;
+  completed_orders: number;
+  cancelled_orders: number;
+  total_revenue: number;
+  avg_order_value: number;
+}
+
 interface WebOrderStatsProps {
-  stats: {
-    total_orders: number;
-    pending_orders: number;
-    completed_orders: number;
-    cancelled_orders: number;
-    total_revenue: number;
-    avg_order_value: number;
-  };
+  stats: WebOrderStatsData;
+  previousStats?: WebOrderStatsData;
   isLoading?: boolean;
   datePreset?: DatePreset;
 }
 
-export function WebOrderStats({ stats, isLoading, datePreset = 'today' }: WebOrderStatsProps) {
+// Indicador de variación porcentual respecto al período anterior
+function TrendBadge({ current, previous, invert, label }: {
+  current: number;
+  previous: number;
+  invert?: boolean;
+  label: string;
+}) {
+  // Sin datos del período anterior: no mostramos comparación
+  if (previous === 0 && current === 0) return null;
+  const delta = current - previous;
+  const pct = previous > 0 ? (delta / previous) * 100 : (current > 0 ? 100 : 0);
+  const isUp = delta > 0;
+  const isFlat = delta === 0;
+  // Por defecto subir = bueno (verde); en métricas "malas" (cancelados) se invierte
+  const isGood = invert ? delta < 0 : delta > 0;
+  const colorClass = isFlat
+    ? 'text-gray-400 dark:text-gray-500'
+    : isGood
+      ? 'text-green-600 dark:text-green-400'
+      : 'text-red-600 dark:text-red-400';
+  return (
+    <div className={`flex items-center gap-0.5 text-xs font-medium ${colorClass}`} title={label}>
+      {isFlat ? (
+        <span>—</span>
+      ) : isUp ? (
+        <ArrowUp className="h-3 w-3" />
+      ) : (
+        <ArrowDown className="h-3 w-3" />
+      )}
+      <span className="tabular-nums">{Math.abs(Math.round(pct))}%</span>
+    </div>
+  );
+}
+
+export function WebOrderStats({ stats, previousStats, isLoading, datePreset = 'today' }: WebOrderStatsProps) {
+  const comparisonLabel = COMPARISON_LABELS[datePreset] || 'vs período previo';
   const statItems = [
     {
       label: DATE_PRESET_LABELS[datePreset] || 'Pedidos',
       value: stats.total_orders,
+      current: stats.total_orders,
+      previous: previousStats?.total_orders,
       icon: <Package className="h-5 w-5" />,
       color: 'text-blue-600 dark:text-blue-400 bg-blue-100 dark:bg-blue-900/30',
     },
     {
       label: 'Pendientes',
       value: stats.pending_orders,
+      current: stats.pending_orders,
+      previous: previousStats?.pending_orders,
       icon: <Clock className="h-5 w-5" />,
       color: 'text-yellow-600 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/30',
       highlight: stats.pending_orders > 0,
@@ -51,24 +103,33 @@ export function WebOrderStats({ stats, isLoading, datePreset = 'today' }: WebOrd
     {
       label: 'Completados',
       value: stats.completed_orders,
+      current: stats.completed_orders,
+      previous: previousStats?.completed_orders,
       icon: <CheckCircle className="h-5 w-5" />,
       color: 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30',
     },
     {
       label: 'Cancelados',
       value: stats.cancelled_orders,
+      current: stats.cancelled_orders,
+      previous: previousStats?.cancelled_orders,
+      invert: true,
       icon: <XCircle className="h-5 w-5" />,
       color: 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30',
     },
     {
       label: 'Ingresos',
       value: `$${stats.total_revenue.toLocaleString()}`,
+      current: stats.total_revenue,
+      previous: previousStats?.total_revenue,
       icon: <DollarSign className="h-5 w-5" />,
       color: 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/30',
     },
     {
       label: 'Ticket promedio',
       value: `$${Math.round(stats.avg_order_value).toLocaleString()}`,
+      current: stats.avg_order_value,
+      previous: previousStats?.avg_order_value,
       icon: <TrendingUp className="h-5 w-5" />,
       color: 'text-purple-600 dark:text-purple-400 bg-purple-100 dark:bg-purple-900/30',
     },
@@ -102,7 +163,17 @@ export function WebOrderStats({ stats, isLoading, datePreset = 'today' }: WebOrd
               {item.icon}
             </div>
             <p className="text-xs sm:text-sm text-muted-foreground dark:text-gray-400 truncate">{item.label}</p>
-            <p className="text-lg sm:text-2xl font-bold dark:text-gray-100 tabular-nums">{item.value}</p>
+            <div className="flex items-baseline gap-1.5 flex-wrap">
+              <p className="text-lg sm:text-2xl font-bold dark:text-gray-100 tabular-nums">{item.value}</p>
+              {previousStats && (
+                <TrendBadge
+                  current={item.current}
+                  previous={item.previous ?? 0}
+                  invert={item.invert}
+                  label={comparisonLabel}
+                />
+              )}
+            </div>
           </CardContent>
         </Card>
       ))}

--- a/src/components/pos/reportes/ReportesPage.tsx
+++ b/src/components/pos/reportes/ReportesPage.tsx
@@ -47,6 +47,7 @@ export function ReportesPage() {
   const [endDate, setEndDate] = useState(() => new Date().toISOString().split('T')[0]);
   const [selectedBranch, setSelectedBranch] = useState<string>('all');
   const [branches, setBranches] = useState<{ id: number; name: string }[]>([]);
+  const [source, setSource] = useState<'pos' | 'web'>('pos');
 
   // Datos
   const [salesSummary, setSalesSummary] = useState<SalesReport | null>(null);
@@ -67,6 +68,7 @@ export function ReportesPage() {
         startDate,
         endDate,
         branchId: selectedBranch !== 'all' ? parseInt(selectedBranch) : undefined,
+        source,
       };
 
       const [summary, products, payments, daily, cash, branchesData] = await Promise.all([
@@ -95,7 +97,7 @@ export function ReportesPage() {
       setLoading(false);
       setIsRefreshing(false);
     }
-  }, [startDate, endDate, selectedBranch, toast]);
+  }, [startDate, endDate, selectedBranch, source, toast]);
 
   useEffect(() => {
     loadData();
@@ -158,7 +160,7 @@ export function ReportesPage() {
               Reportes POS
             </h1>
             <p className="text-gray-500 dark:text-gray-400">
-              POS / Reportes
+              POS / Reportes · {source === 'web' ? 'Ventas Web' : 'Ventas POS'}
             </p>
           </div>
         </div>
@@ -176,6 +178,30 @@ export function ReportesPage() {
       {/* Filtros */}
       <Card className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
         <CardContent className="pt-4">
+          {/* Toggle de origen de ventas */}
+          <div className="mb-4">
+            <Label className="text-gray-700 dark:text-gray-300">Origen de ventas</Label>
+            <div className="mt-1 inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-50 dark:bg-gray-900">
+              <Button
+                variant={source === 'pos' ? 'default' : 'ghost'}
+                size="sm"
+                onClick={() => setSource('pos')}
+                className={source === 'pos' ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'text-gray-600 dark:text-gray-300'}
+              >
+                <ShoppingCart className="h-4 w-4 mr-2" />
+                Ventas POS
+              </Button>
+              <Button
+                variant={source === 'web' ? 'default' : 'ghost'}
+                size="sm"
+                onClick={() => setSource('web')}
+                className={source === 'web' ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'text-gray-600 dark:text-gray-300'}
+              >
+                <ShoppingCart className="h-4 w-4 mr-2" />
+                Ventas Web
+              </Button>
+            </div>
+          </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4">
             <div>
               <Label className="text-gray-700 dark:text-gray-300">Fecha Inicio</Label>
@@ -359,7 +385,8 @@ export function ReportesPage() {
         </Card>
       </div>
 
-      {/* Resumen de Caja */}
+      {/* Resumen de Caja (solo aplica a ventas POS) */}
+      {source === 'pos' && (
       <Card className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
         <CardHeader>
           <CardTitle className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
@@ -455,6 +482,7 @@ export function ReportesPage() {
           </div>
         </CardContent>
       </Card>
+      )}
 
       {/* Impuestos y Descuentos */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/src/components/pos/reportes/reportesService.ts
+++ b/src/components/pos/reportes/reportesService.ts
@@ -37,12 +37,18 @@ export interface DailySalesData {
   transactions: number;
 }
 
+export type ReportSource = 'pos' | 'web';
+
 export interface ReportFilters {
   startDate: string;
   endDate: string;
   branchId?: number;
   cashierId?: string;
+  source?: ReportSource;
 }
+
+// Estados de web_orders que cuentan como venta realizada (excluye pending/cancelled/rejected)
+const WEB_SALE_STATUSES = ['confirmed', 'preparing', 'ready', 'in_delivery', 'delivered'];
 
 export class ReportesService {
   private static organizationId = getOrganizationId();
@@ -68,13 +74,22 @@ export class ReportesService {
     }
 
     try {
-      let query = supabase
-        .from('sales')
-        .select('id, total, subtotal, tax_total, discount_total')
-        .eq('organization_id', orgId)
-        .gte('sale_date', filters.startDate)
-        .lte('sale_date', filters.endDate + 'T23:59:59')
-        .in('status', ['completed', 'paid']);
+      const isWeb = filters.source === 'web';
+      let query = isWeb
+        ? supabase
+            .from('web_orders')
+            .select('id, total, subtotal, tax_total, discount_total')
+            .eq('organization_id', orgId)
+            .gte('created_at', filters.startDate)
+            .lte('created_at', filters.endDate + 'T23:59:59')
+            .in('status', WEB_SALE_STATUSES)
+        : supabase
+            .from('sales')
+            .select('id, total, subtotal, tax_total, discount_total')
+            .eq('organization_id', orgId)
+            .gte('sale_date', filters.startDate)
+            .lte('sale_date', filters.endDate + 'T23:59:59')
+            .in('status', ['completed', 'paid']);
 
       if (filters.branchId) {
         query = query.eq('branch_id', filters.branchId);
@@ -96,10 +111,9 @@ export class ReportesService {
       let totalItems = 0;
       if (data && data.length > 0) {
         const saleIds = data.map(s => s.id);
-        const { data: itemsData } = await supabase
-          .from('sale_items')
-          .select('quantity')
-          .in('sale_id', saleIds);
+        const { data: itemsData } = isWeb
+          ? await supabase.from('web_order_items').select('quantity').in('web_order_id', saleIds)
+          : await supabase.from('sale_items').select('quantity').in('sale_id', saleIds);
 
         totalItems = itemsData?.reduce((sum, item) => sum + Number(item.quantity || 0), 0) || 0;
       }
@@ -132,14 +146,24 @@ export class ReportesService {
     if (!orgId) return [];
 
     try {
-      // Primero obtener las ventas completadas en el rango
-      let salesQuery = supabase
-        .from('sales')
-        .select('id')
-        .eq('organization_id', orgId)
-        .gte('sale_date', filters.startDate)
-        .lte('sale_date', filters.endDate + 'T23:59:59')
-        .in('status', ['completed', 'paid']);
+      const isWeb = filters.source === 'web';
+
+      // Primero obtener las ventas realizadas en el rango (POS o Web)
+      let salesQuery = isWeb
+        ? supabase
+            .from('web_orders')
+            .select('id')
+            .eq('organization_id', orgId)
+            .gte('created_at', filters.startDate)
+            .lte('created_at', filters.endDate + 'T23:59:59')
+            .in('status', WEB_SALE_STATUSES)
+        : supabase
+            .from('sales')
+            .select('id')
+            .eq('organization_id', orgId)
+            .gte('sale_date', filters.startDate)
+            .lte('sale_date', filters.endDate + 'T23:59:59')
+            .in('status', ['completed', 'paid']);
 
       if (filters.branchId) {
         salesQuery = salesQuery.eq('branch_id', filters.branchId);
@@ -153,44 +177,72 @@ export class ReportesService {
 
       const saleIds = salesData.map(s => s.id);
 
-      // Obtener items de esas ventas con productos
-      const { data, error } = await supabase
-        .from('sale_items')
-        .select(`
-          product_id,
-          quantity,
-          total,
-          products(id, name, category_id, categories(name))
-        `)
-        .in('sale_id', saleIds);
-
-      if (error) {
-        console.error('Error getTopProducts:', error);
-        return [];
-      }
-
       // Agrupar por producto
-      const productMap = new Map<number, ProductReport>();
-      
-      data?.forEach(item => {
-        const productId = item.product_id;
-        if (!productId) return;
-        
-        const existing = productMap.get(productId);
-        
-        if (existing) {
-          existing.quantity_sold += Number(item.quantity || 0);
-          existing.total_revenue += Number(item.total || 0);
-        } else {
-          productMap.set(productId, {
-            product_id: productId,
-            product_name: (item.products as any)?.name || 'Producto',
-            quantity_sold: Number(item.quantity || 0),
-            total_revenue: Number(item.total || 0),
-            category_name: (item.products as any)?.categories?.name,
-          });
+      const productMap = new Map<string, ProductReport>();
+
+      if (isWeb) {
+        // Items web (incluyen product_name embebido)
+        const { data, error } = await supabase
+          .from('web_order_items')
+          .select('product_id, product_name, quantity, total')
+          .in('web_order_id', saleIds);
+
+        if (error) {
+          console.error('Error getTopProducts web:', error);
+          return [];
         }
-      });
+
+        data?.forEach(item => {
+          const key = item.product_id ? `id:${item.product_id}` : `name:${item.product_name}`;
+          const existing = productMap.get(key);
+          if (existing) {
+            existing.quantity_sold += Number(item.quantity || 0);
+            existing.total_revenue += Number(item.total || 0);
+          } else {
+            productMap.set(key, {
+              product_id: item.product_id || 0,
+              product_name: item.product_name || 'Producto',
+              quantity_sold: Number(item.quantity || 0),
+              total_revenue: Number(item.total || 0),
+            });
+          }
+        });
+      } else {
+        // Items POS con relación a products
+        const { data, error } = await supabase
+          .from('sale_items')
+          .select(`
+            product_id,
+            quantity,
+            total,
+            products(id, name, category_id, categories(name))
+          `)
+          .in('sale_id', saleIds);
+
+        if (error) {
+          console.error('Error getTopProducts:', error);
+          return [];
+        }
+
+        data?.forEach(item => {
+          const productId = item.product_id;
+          if (!productId) return;
+          const key = `id:${productId}`;
+          const existing = productMap.get(key);
+          if (existing) {
+            existing.quantity_sold += Number(item.quantity || 0);
+            existing.total_revenue += Number(item.total || 0);
+          } else {
+            productMap.set(key, {
+              product_id: productId,
+              product_name: (item.products as any)?.name || 'Producto',
+              quantity_sold: Number(item.quantity || 0),
+              total_revenue: Number(item.total || 0),
+              category_name: (item.products as any)?.categories?.name,
+            });
+          }
+        });
+      }
 
       // Ordenar por cantidad vendida y limitar
       return Array.from(productMap.values())
@@ -209,14 +261,24 @@ export class ReportesService {
     if (!orgId) return [];
 
     try {
-      // Consulta directa a payments filtrada por organization_id y fechas
-      let query = supabase
-        .from('payments')
-        .select('method, amount, created_at')
-        .eq('organization_id', orgId)
-        .gte('created_at', filters.startDate)
-        .lte('created_at', filters.endDate + 'T23:59:59')
-        .in('status', ['completed', 'paid']);
+      const isWeb = filters.source === 'web';
+
+      // Web: el método de pago vive en web_orders. POS: tabla payments.
+      let query = isWeb
+        ? supabase
+            .from('web_orders')
+            .select('payment_method, total')
+            .eq('organization_id', orgId)
+            .gte('created_at', filters.startDate)
+            .lte('created_at', filters.endDate + 'T23:59:59')
+            .in('status', WEB_SALE_STATUSES)
+        : supabase
+            .from('payments')
+            .select('method, amount, created_at')
+            .eq('organization_id', orgId)
+            .gte('created_at', filters.startDate)
+            .lte('created_at', filters.endDate + 'T23:59:59')
+            .in('status', ['completed', 'paid']);
 
       if (filters.branchId) {
         query = query.eq('branch_id', filters.branchId);
@@ -229,22 +291,19 @@ export class ReportesService {
         return [];
       }
 
-      // Agrupar por método
+      // Agrupar por método (normalizando los campos según el origen)
       const methodMap = new Map<string, PaymentMethodReport>();
-      
-      data?.forEach(payment => {
-        const method = payment.method || 'other';
+
+      data?.forEach((row: any) => {
+        const method = (isWeb ? row.payment_method : row.method) || 'other';
+        const amount = Number((isWeb ? row.total : row.amount) || 0);
         const existing = methodMap.get(method);
-        
+
         if (existing) {
           existing.count += 1;
-          existing.total += Number(payment.amount || 0);
+          existing.total += amount;
         } else {
-          methodMap.set(method, {
-            method,
-            count: 1,
-            total: Number(payment.amount || 0),
-          });
+          methodMap.set(method, { method, count: 1, total: amount });
         }
       });
 
@@ -262,14 +321,25 @@ export class ReportesService {
     if (!orgId) return [];
 
     try {
-      let query = supabase
-        .from('sales')
-        .select('sale_date, total')
-        .eq('organization_id', orgId)
-        .gte('sale_date', filters.startDate)
-        .lte('sale_date', filters.endDate + 'T23:59:59')
-        .in('status', ['completed', 'paid'])
-        .order('sale_date', { ascending: true });
+      const isWeb = filters.source === 'web';
+      const dateField = isWeb ? 'created_at' : 'sale_date';
+      let query = isWeb
+        ? supabase
+            .from('web_orders')
+            .select('created_at, total')
+            .eq('organization_id', orgId)
+            .gte('created_at', filters.startDate)
+            .lte('created_at', filters.endDate + 'T23:59:59')
+            .in('status', WEB_SALE_STATUSES)
+            .order('created_at', { ascending: true })
+        : supabase
+            .from('sales')
+            .select('sale_date, total')
+            .eq('organization_id', orgId)
+            .gte('sale_date', filters.startDate)
+            .lte('sale_date', filters.endDate + 'T23:59:59')
+            .in('status', ['completed', 'paid'])
+            .order('sale_date', { ascending: true });
 
       if (filters.branchId) {
         query = query.eq('branch_id', filters.branchId);
@@ -285,8 +355,9 @@ export class ReportesService {
       // Agrupar por fecha
       const dateMap = new Map<string, DailySalesData>();
       
-      data?.forEach(sale => {
-        const date = sale.sale_date ? sale.sale_date.split('T')[0] : '';
+      data?.forEach((sale: any) => {
+        const raw = sale[dateField];
+        const date = raw ? String(raw).split('T')[0] : '';
         if (!date) return;
         
         const existing = dateMap.get(date);
@@ -319,6 +390,31 @@ export class ReportesService {
     }
 
     try {
+      // Web: no hay sesiones de caja; solo calculamos el total de ventas web del período
+      if (filters.source === 'web') {
+        let webQuery = supabase
+          .from('web_orders')
+          .select('total')
+          .eq('organization_id', orgId)
+          .gte('created_at', filters.startDate)
+          .lte('created_at', filters.endDate + 'T23:59:59')
+          .in('status', WEB_SALE_STATUSES);
+
+        if (filters.branchId) {
+          webQuery = webQuery.eq('branch_id', filters.branchId);
+        }
+
+        const { data: webData } = await webQuery;
+        const totalVentasWeb = webData?.reduce((sum, o) => sum + Number(o.total || 0), 0) || 0;
+        return {
+          sessions: [],
+          totalIngresos: 0,
+          totalEgresos: 0,
+          totalVentas: totalVentasWeb,
+          balance: totalVentasWeb,
+        };
+      }
+
       // Consulta de sesiones de caja
       let sessionsQuery = supabase
         .from('cash_sessions')


### PR DESCRIPTION
… iOS

- get_web_conversion_stats: contar confirmados por payment_status=paid OR status=delivered
- get_web_top_products: mismo criterio de ventas realizadas
- Ambas RPCs: interpretar rango de fechas en zona America/Bogota (no UTC)
- AppLayout: agregar min-w-0 a columna de contenido para evitar overflow horizontal
- globals.css: agregar utilidad h-dynamic-screen (100dvh) para iOS Safari
- AppLayout: reemplazar h-screen por h-dynamic-screen en contenedor raiz y sidebar