### PR TITLE
Main

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -749,7 +749,11 @@
     "manageOrgs": {
       "title": "Manage Organizations",
       "createNew": "Create New Organization",
-      "confirmDelete": "Are you sure you want to delete this organization? This action cannot be undone.",
+      "confirmDelete": "Delete organization?",
+      "confirmDeleteDescription": "This will delete the organization, its branches and all associated data. This action cannot be undone.",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "deleting": "Deleting...",
       "noSession": "User session not found",
       "noPermissionsDelete": "You do not have permission to delete this organization",
       "loadingForm": "Loading form...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -749,7 +749,11 @@
     "manageOrgs": {
       "title": "Administrar Organizaciones",
       "createNew": "Crear Nueva Organización",
-      "confirmDelete": "¿Estás seguro de eliminar esta organización? Esta acción no se puede deshacer.",
+      "confirmDelete": "¿Eliminar organización?",
+      "confirmDeleteDescription": "Esta acción eliminará la organización, sus sucursales y todos los datos asociados. No se puede deshacer.",
+      "cancel": "Cancelar",
+      "delete": "Eliminar",
+      "deleting": "Eliminando...",
       "noSession": "No se encontró sesión de usuario",
       "noPermissionsDelete": "No tienes permisos para eliminar esta organización",
       "loadingForm": "Cargando formulario...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -749,7 +749,11 @@
     "manageOrgs": {
       "title": "Gérer les organisations",
       "createNew": "Créer une nouvelle organisation",
-      "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette organisation ? Cette action est irréversible.",
+      "confirmDelete": "Supprimer l'organisation ?",
+      "confirmDeleteDescription": "Cette action supprimera l'organisation, ses succursales et toutes les données associées. Cette action est irréversible.",
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "deleting": "Suppression...",
       "noSession": "Session utilisateur introuvable",
       "noPermissionsDelete": "Vous n'avez pas la permission de supprimer cette organisation",
       "loadingForm": "Chargement du formulaire...",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -749,7 +749,11 @@
     "manageOrgs": {
       "title": "Gerenciar Organizações",
       "createNew": "Criar Nova Organização",
-      "confirmDelete": "Tem certeza de que deseja excluir esta organização? Esta ação não pode ser desfeita.",
+      "confirmDelete": "Excluir organização?",
+      "confirmDeleteDescription": "Esta ação excluirá a organização, suas filiais e todos os dados associados. Esta ação não pode ser desfeita.",
+      "cancel": "Cancelar",
+      "delete": "Excluir",
+      "deleting": "Excluindo...",
       "noSession": "Sessão de usuário não encontrada",
       "noPermissionsDelete": "Você não tem permissão para excluir esta organização",
       "loadingForm": "Carregando formulário...",

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -37,9 +37,25 @@ const createClientWithSession = async () => {
       detectSessionInUrl: false,
       flowType: 'pkce',
       // Cookie storage personalizada para Next.js App Router
+      // Soporta cookies chunked (.0, .1, .2...) para tokens grandes
       storage: {
         getItem: (key: string) => {
-          return cookieStore.get(key)?.value ?? null
+          const direct = cookieStore.get(key)?.value
+          if (direct) return direct
+          // Buscar cookies chunked
+          const chunk0 = cookieStore.get(`${key}.0`)
+          if (chunk0) {
+            let fullValue = chunk0.value
+            let i = 1
+            while (true) {
+              const chunk = cookieStore.get(`${key}.${i}`)
+              if (!chunk) break
+              fullValue += chunk.value
+              i++
+            }
+            return fullValue
+          }
+          return null
         },
         setItem: () => {},
         removeItem: () => {}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -81,6 +81,15 @@ interface SignupData {
   stripePaymentMethodId?: string;
   // Cupón de descuento
   couponCode?: string;
+  validatedCoupon?: {
+    code: string;
+    name: string;
+    discountType: 'percentage' | 'fixed';
+    discountValue: number;
+    durationMonths: number | null;
+    discountDescription: string;
+    durationDescription: string;
+  } | null;
 }
 
 function SignupContent() {
@@ -304,6 +313,7 @@ function SignupContent() {
             state: signupData.organizationState || null,
             country: signupData.organizationCountry || 'Colombia',
             country_code: signupData.organizationCountryCode || 'COL',
+            municipality_id: signupData.organizationMunicipalityId || null,
             postal_code: signupData.organizationPostalCode || null,
             primary_color: signupData.organizationPrimaryColor || '#3B82F6',
             secondary_color: signupData.organizationSecondaryColor || '#F59E0B',

--- a/src/components/app-layout/AccountSwitcher.tsx
+++ b/src/components/app-layout/AccountSwitcher.tsx
@@ -12,6 +12,7 @@ import {
   X,
   Loader2,
   AlertTriangle,
+  Settings,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { UserData } from './types';
@@ -229,7 +230,10 @@ export const AccountSwitcher = ({ userData, collapsed = false }: AccountSwitcher
   // Cuerpo común del panel: cuentas guardadas + acciones de la cuenta activa
   const renderPanelBody = () => (
     <>
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+      <button
+        onClick={() => { setOpen(false); router.push('/app/perfil'); }}
+        className="w-full p-4 border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left"
+      >
         <div className="flex items-center">
           {renderAvatar(userData?.avatar, userData?.name, 48)}
           <div className="ml-3 flex-1 min-w-0">
@@ -244,8 +248,9 @@ export const AccountSwitcher = ({ userData, collapsed = false }: AccountSwitcher
               </div>
             )}
           </div>
+          <ChevronRight size={16} className="text-gray-400 flex-shrink-0 ml-2" />
         </div>
-      </div>
+      </button>
 
       {switchError && (
         <div className="px-4 py-2 text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border-b border-red-100 dark:border-red-900/30">

--- a/src/components/app-layout/AppLayout.tsx
+++ b/src/components/app-layout/AppLayout.tsx
@@ -922,6 +922,21 @@ export const AppLayout = ({
     // Obtener ID de organización
     const storedOrgId = localStorage.getItem('currentOrganizationId');
     setOrgId(storedOrgId);
+
+    // Escuchar cambios de organización sin recargar la página
+    const handleOrgChange = () => {
+      const newOrgId = localStorage.getItem('currentOrganizationId');
+      const newOrgName = localStorage.getItem('currentOrganizationName');
+      setOrgId(newOrgId);
+      if (newOrgName) setOrgName(newOrgName);
+      // Forzar recarga del perfil y módulos con la nueva org
+      setProfileRefresh(prev => prev + 1);
+    };
+    window.addEventListener('organization-changed', handleOrgChange);
+
+    return () => {
+      window.removeEventListener('organization-changed', handleOrgChange);
+    };
   }, []);
   
   // Importación dinámica de la función signOut (memoizada)

--- a/src/components/app-layout/ProfileDropdownMenu.tsx
+++ b/src/components/app-layout/ProfileDropdownMenu.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { Building2, LogOut, CreditCard, X } from 'lucide-react';
+import { Building2, LogOut, CreditCard, X, MailWarning, Send } from 'lucide-react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { ChevronDown, User, Settings, Bell, ChevronRight } from 'lucide-react';
@@ -27,6 +27,10 @@ export const ProfileDropdownMenu = ({ userData, handleSignOut, loading, isSideba
   const [isMobile, setIsMobile] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
+  const [emailConfirmed, setEmailConfirmed] = useState(true);
+  const [resendingEmail, setResendingEmail] = useState(false);
+  const [canResendEmail, setCanResendEmail] = useState(true);
+  const [resendEmailTimer, setResendEmailTimer] = useState(0);
   const t = useTranslations('nav');
   
   // Detectar si estamos en móvil y si el componente está montado
@@ -37,6 +41,43 @@ export const ProfileDropdownMenu = ({ userData, handleSignOut, loading, isSideba
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
+
+  // Verificar si el correo del usuario está confirmado
+  useEffect(() => {
+    const checkEmailConfirmed = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      setEmailConfirmed(!!user?.email_confirmed_at);
+    };
+    checkEmailConfirmed();
+  }, []);
+
+  const startResendEmailTimer = () => {
+    setCanResendEmail(false);
+    setResendEmailTimer(60);
+    const timer = setInterval(() => {
+      setResendEmailTimer((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          setCanResendEmail(true);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  const handleResendConfirmation = async () => {
+    if (resendingEmail || !canResendEmail || !userData?.email) return;
+    setResendingEmail(true);
+    try {
+      const { error } = await supabase.auth.resend({ type: 'signup', email: userData.email });
+      if (!error) startResendEmailTimer();
+    } catch {
+      // silenciar error
+    } finally {
+      setResendingEmail(false);
+    }
+  };
 
   // Cargar plan de suscripción (se recarga si cambia la org en storage)
   useEffect(() => {
@@ -137,6 +178,20 @@ export const ProfileDropdownMenu = ({ userData, handleSignOut, loading, isSideba
                   )}
                   {userData?.email && (
                     <p className="text-sm text-gray-500 dark:text-gray-400 truncate mt-1">{userData.email}</p>
+                  )}
+                  {!emailConfirmed && (
+                    <button
+                      onClick={handleResendConfirmation}
+                      disabled={resendingEmail || !canResendEmail}
+                      className="flex items-center gap-1 mt-1.5 text-xs font-medium text-amber-600 dark:text-amber-400 disabled:opacity-60"
+                    >
+                      <MailWarning size={13} />
+                      <span>
+                        {t('emailNotConfirmed', { defaultValue: 'Correo sin confirmar' })}
+                        {' · '}
+                        {resendingEmail ? t('sending', { defaultValue: 'Enviando...' }) : !canResendEmail ? `${resendEmailTimer}s` : t('resend', { defaultValue: 'Reenviar' })}
+                      </span>
+                    </button>
                   )}
                   {planName && (
                     <div className="flex items-center mt-2 text-sm text-blue-600 dark:text-blue-400 font-medium">
@@ -449,6 +504,20 @@ export const ProfileDropdownMenu = ({ userData, handleSignOut, loading, isSideba
             )}
             {userData?.email && (
               <p className="truncate">{userData.email}</p>
+            )}
+            {!emailConfirmed && (
+              <button
+                onClick={handleResendConfirmation}
+                disabled={resendingEmail || !canResendEmail}
+                className="flex items-center gap-1 mt-1 text-xs font-medium text-amber-600 dark:text-amber-400 disabled:opacity-60"
+              >
+                <MailWarning size={12} />
+                <span>
+                  {t('emailNotConfirmed', { defaultValue: 'Correo sin confirmar' })}
+                  {' · '}
+                  {resendingEmail ? t('sending', { defaultValue: 'Enviando...' }) : !canResendEmail ? `${resendEmailTimer}s` : t('resend', { defaultValue: 'Reenviar' })}
+                </span>
+              </button>
             )}
           </div>
         </div>

--- a/src/components/auth/EmailConfirmedGate.tsx
+++ b/src/components/auth/EmailConfirmedGate.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { MailWarning } from 'lucide-react';
+import { useEmailConfirmed } from '@/hooks/useEmailConfirmed';
+
+interface EmailConfirmedGateProps {
+  children: ReactNode;
+  /**
+   * Si true (default), envuelve el children en un <span> con tooltip y lo
+   * deshabilita visualmente en vez de ocultarlo por completo. Útil para
+   * botones donde queremos que el usuario vea la acción pero no pueda usarla.
+   */
+  disableInsteadOfHide?: boolean;
+  message?: string;
+}
+
+/**
+ * Restringe una acción sensible (cambiar contraseña, facturación, invitar
+ * usuarios) a solo cuentas con email confirmado. Mientras carga el estado,
+ * no bloquea (evita parpadeos); una vez confirmado que no está verificado,
+ * deshabilita/oculta el contenido.
+ */
+export function EmailConfirmedGate({
+  children,
+  disableInsteadOfHide = true,
+  message = 'Confirma tu correo electrónico para usar esta función'
+}: EmailConfirmedGateProps) {
+  const { confirmed, loading } = useEmailConfirmed();
+
+  if (loading || confirmed) {
+    return <>{children}</>;
+  }
+
+  if (!disableInsteadOfHide) {
+    return null;
+  }
+
+  return (
+    <span
+      title={message}
+      className="relative inline-block cursor-not-allowed opacity-50 [&_button]:pointer-events-none [&_a]:pointer-events-none"
+    >
+      {children}
+      <span className="sr-only">{message}</span>
+    </span>
+  );
+}
+
+/**
+ * Variante para mostrar un mensaje de advertencia en vez de envolver un
+ * elemento existente (por ejemplo, arriba de un formulario completo).
+ */
+export function EmailConfirmedWarning({ message = 'Debes confirmar tu correo electrónico para usar esta función.' }: { message?: string }) {
+  const { confirmed, loading } = useEmailConfirmed();
+
+  if (loading || confirmed) return null;
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-sm text-amber-700 dark:text-amber-300 mb-3">
+      <MailWarning className="h-4 w-4 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/src/components/auth/PaymentMethodStep.tsx
+++ b/src/components/auth/PaymentMethodStep.tsx
@@ -10,6 +10,8 @@ import {
 } from '@stripe/react-stripe-js';
 import { CreditCardIcon, CheckCircleIcon, ExclamationTriangleIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import { useTranslations } from 'next-intl';
+import PriceSummary from './PriceSummary';
+import type { CouponData } from './PriceSummary';
 
 // Cargar Stripe
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || '');
@@ -20,7 +22,9 @@ interface PaymentMethodStepProps {
     firstName: string;
     lastName: string;
     subscriptionPlan: string;
+    billingPeriod?: 'monthly' | 'yearly';
     skipTrial?: boolean;
+    validatedCoupon?: CouponData | null;
   };
   updateFormData: (data: any) => void;
   onNext: () => void;
@@ -171,6 +175,7 @@ function PaymentForm({ formData, updateFormData, onNext, onBack, onSkip, loading
 
   const isPaidPlan = formData.subscriptionPlan !== 'free';
   const isPayNow = formData.skipTrial === true;
+  const billingPeriod = formData.billingPeriod || 'monthly';
 
   return (
     <div className="space-y-4 sm:space-y-5">
@@ -203,6 +208,17 @@ function PaymentForm({ formData, updateFormData, onNext, onBack, onSkip, loading
           </div>
         )}
       </div>
+
+      {/* Resumen de pago */}
+      {isPaidPlan && (
+        <PriceSummary
+          subscriptionPlan={formData.subscriptionPlan}
+          billingPeriod={billingPeriod}
+          skipTrial={isPayNow}
+          coupon={formData.validatedCoupon || null}
+          compact
+        />
+      )}
 
       {/* Tarjeta verificada */}
       {paymentVerified && verifiedCard ? (

--- a/src/components/auth/PriceSummary.tsx
+++ b/src/components/auth/PriceSummary.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase/config';
+import { TagIcon, CheckCircle2 } from 'lucide-react';
+
+export interface CouponData {
+  code: string;
+  name: string;
+  discountType: 'percentage' | 'fixed';
+  discountValue: number;
+  durationMonths: number | null;
+  discountDescription: string;
+  durationDescription: string;
+}
+
+interface PriceSummaryProps {
+  subscriptionPlan: string;
+  billingPeriod: 'monthly' | 'yearly';
+  skipTrial?: boolean;
+  coupon?: CouponData | null;
+  compact?: boolean;
+}
+
+export default function PriceSummary({
+  subscriptionPlan,
+  billingPeriod,
+  skipTrial = false,
+  coupon = null,
+  compact = false,
+}: PriceSummaryProps) {
+  const [planPrice, setPlanPrice] = useState<number | null>(null);
+  const [planName, setPlanName] = useState<string>('');
+
+  useEffect(() => {
+    const fetchPlanPrice = async () => {
+      const planCode = (subscriptionPlan || 'pro').replace('-yearly', '');
+      const { data } = await supabase
+        .from('plans')
+        .select('name, price_usd_month, price_usd_year')
+        .eq('code', planCode)
+        .single();
+
+      if (data) {
+        setPlanName(data.name);
+        const price = billingPeriod === 'yearly'
+          ? parseFloat(data.price_usd_year)
+          : parseFloat(data.price_usd_month);
+        setPlanPrice(price);
+      }
+    };
+    fetchPlanPrice();
+  }, [subscriptionPlan, billingPeriod]);
+
+  if (planPrice === null) return null;
+
+  const periodLabel = billingPeriod === 'monthly' ? '/mes' : '/año';
+  const periodLabelShort = billingPeriod === 'monthly' ? 'mensual' : 'anual';
+
+  let discountAmount = 0;
+  let finalPrice = planPrice;
+
+  if (coupon) {
+    if (coupon.discountType === 'percentage') {
+      discountAmount = planPrice * (coupon.discountValue / 100);
+    } else {
+      discountAmount = Math.min(coupon.discountValue, planPrice);
+    }
+    finalPrice = Math.max(planPrice - discountAmount, 0);
+  }
+
+  const padding = compact ? 'p-3' : 'p-4';
+  const textSize = compact ? 'text-xs' : 'text-sm';
+  const titleSize = compact ? 'text-sm' : 'text-base';
+
+  return (
+    <div className={`mt-3 sm:mt-4 ${padding} bg-white border border-gray-200 rounded-lg shadow-sm`}>
+      <h4 className={`${titleSize} font-semibold text-gray-900 mb-2 sm:mb-3 flex items-center gap-1.5`}>
+        <TagIcon className="h-4 w-4 text-blue-600" />
+        Resumen de pago
+      </h4>
+
+      <div className="space-y-1.5">
+        <div className="flex justify-between items-center text-xs sm:text-sm">
+          <span className="text-gray-600">Plan {planName} ({periodLabelShort})</span>
+          <span className="font-medium text-gray-900">${planPrice.toFixed(2)} {periodLabel}</span>
+        </div>
+
+        {coupon && discountAmount > 0 && (
+          <div className="flex justify-between items-center text-xs sm:text-sm text-green-700">
+            <span className="flex items-center gap-1">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              Descuento ({coupon.code})
+            </span>
+            <span className="font-medium">-${discountAmount.toFixed(2)}</span>
+          </div>
+        )}
+
+        {coupon && coupon.durationMonths && (
+          <p className="text-[11px] text-green-600 italic">
+            {coupon.durationDescription}
+          </p>
+        )}
+
+        <div className="border-t border-gray-200 pt-1.5 mt-1.5">
+          <div className="flex justify-between items-center">
+            <span className={`${textSize} font-semibold text-gray-900`}>Total a pagar</span>
+            <span className={`${textSize} font-bold text-gray-900`}>
+              ${finalPrice.toFixed(2)} {periodLabel}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {skipTrial ? (
+        <p className="mt-2 text-[11px] sm:text-xs text-amber-600 flex items-center gap-1">
+          Se cobrará ahora al verificar la tarjeta
+        </p>
+      ) : (
+        <p className="mt-2 text-[11px] sm:text-xs text-green-600 flex items-center gap-1">
+          <CheckCircle2 className="h-3 w-3" />
+          No se cobrará hasta que termine el período de prueba
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/auth/SubscriptionStep.tsx
+++ b/src/components/auth/SubscriptionStep.tsx
@@ -5,6 +5,7 @@ import SubscriptionPlanSelector from '../subscription/SubscriptionPlanSelector';
 import { useTranslations } from 'next-intl';
 import { supabase } from '@/lib/supabase/config';
 import { Ticket, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import PriceSummary from './PriceSummary';
 
 export interface ValidatedCoupon {
   id: string;
@@ -114,10 +115,21 @@ export default function SubscriptionStep({
 
       if (data.valid && data.coupon) {
         setValidatedCoupon(data.coupon);
-        updateFormData({ couponCode: data.coupon.code });
+        updateFormData({
+          couponCode: data.coupon.code,
+          validatedCoupon: {
+            code: data.coupon.code,
+            name: data.coupon.name,
+            discountType: data.coupon.discountType,
+            discountValue: data.coupon.discountValue,
+            durationMonths: data.coupon.durationMonths,
+            discountDescription: data.coupon.discountDescription,
+            durationDescription: data.coupon.durationDescription,
+          },
+        });
       } else {
         setCouponError(data.error || 'Cupón no válido');
-        updateFormData({ couponCode: undefined });
+        updateFormData({ couponCode: undefined, validatedCoupon: null });
       }
     } catch {
       setCouponError('Error al validar el cupón');
@@ -131,7 +143,7 @@ export default function SubscriptionStep({
     setCouponInput('');
     setValidatedCoupon(null);
     setCouponError(null);
-    updateFormData({ couponCode: undefined });
+    updateFormData({ couponCode: undefined, validatedCoupon: null });
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -220,7 +232,7 @@ export default function SubscriptionStep({
           </p>
 
           {!validatedCoupon ? (
-            <div className="flex gap-2">
+            <div className="flex flex-col sm:flex-row gap-2">
               <input
                 type="text"
                 value={couponInput}
@@ -235,14 +247,14 @@ export default function SubscriptionStep({
                   }
                 }}
                 placeholder={t('couponPlaceholder')}
-                className="flex-1 rounded-md border border-gray-300 px-3 py-1.5 sm:py-2 text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent uppercase"
+                className="w-full sm:flex-1 rounded-md border border-gray-300 px-3 py-2 text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent uppercase"
                 disabled={couponLoading}
               />
               <button
                 type="button"
                 onClick={handleValidateCoupon}
                 disabled={couponLoading || !couponInput.trim()}
-                className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-3 py-1.5 sm:py-2 text-xs sm:text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="w-full sm:w-auto inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-xs sm:text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
               >
                 {couponLoading ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -253,7 +265,7 @@ export default function SubscriptionStep({
             </div>
           ) : (
             <div className="flex items-center justify-between gap-2 p-2.5 sm:p-3 rounded-md border border-green-300 bg-green-50">
-              <div className="flex items-center gap-2 min-w-0">
+              <div className="flex items-center gap-2 min-w-0 flex-1">
                 <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0" />
                 <div className="min-w-0">
                   <p className="text-xs sm:text-sm font-medium text-green-900 truncate">
@@ -281,6 +293,14 @@ export default function SubscriptionStep({
             </div>
           )}
         </div>
+
+        {/* Resumen de pago */}
+        <PriceSummary
+          subscriptionPlan={selectedPlan}
+          billingPeriod={billingPeriod}
+          skipTrial={skipTrial}
+          coupon={validatedCoupon}
+        />
 
         <div className="mt-6 sm:mt-8 flex justify-between gap-2">
           <button

--- a/src/components/inventario/productos/editar/FormularioEdicionProducto.tsx
+++ b/src/components/inventario/productos/editar/FormularioEdicionProducto.tsx
@@ -329,15 +329,19 @@ export default function FormularioEdicionProducto({ productoUuid }: FormularioEd
     
     try {
       // 1. Actualizar los datos principales del producto
-      const productoData = {
-        ...data,
-        organization_id
+      // Solo enviar campos que existen en la tabla products
+      const productoData: Record<string, any> = {
+        sku: data.sku,
+        barcode: data.barcode || null,
+        name: data.name,
+        description: data.description || null,
+        category_id: data.category_id ?? null,
+        unit_code: data.unit_code,
+        status: data.status,
+        station: data.station ?? null,
+        updated_at: new Date().toISOString(),
       };
-      
-      // Eliminar campos que no corresponden a la tabla de productos
-      delete productoData.stock_inicial;
-      
-      // Actualizar el producto
+
       const { error } = await supabase
         .from('products')
         .update(productoData)
@@ -347,6 +351,79 @@ export default function FormularioEdicionProducto({ productoUuid }: FormularioEd
       if (error) throw error;
       
       console.log("Datos principales del producto actualizados correctamente");
+
+      // 1b. Actualizar precio en product_prices si cambió
+      if (data.price !== undefined && data.price >= 0) {
+        const now = new Date().toISOString();
+        // Cerrar precio vigente actual
+        const { data: currentPrice } = await supabase
+          .from('product_prices')
+          .select('id, price, compare_price')
+          .eq('product_id', productoId)
+          .is('effective_to', null)
+          .order('effective_from', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        const hasCompare = data.compare_price && data.compare_price > 0;
+        const priceChanged = !currentPrice || currentPrice.price !== data.price ||
+          (currentPrice.compare_price || 0) !== (data.compare_price || 0);
+
+        if (priceChanged) {
+          if (currentPrice) {
+            await supabase
+              .from('product_prices')
+              .update({ effective_to: now })
+              .eq('id', currentPrice.id);
+          }
+          const newPriceData: Record<string, any> = {
+            product_id: productoId,
+            price: data.price,
+            effective_from: now,
+            effective_to: null,
+          };
+          if (hasCompare) {
+            newPriceData.compare_price = data.compare_price;
+          }
+          const { error: priceError } = await supabase
+            .from('product_prices')
+            .insert(newPriceData);
+          if (priceError) throw priceError;
+        }
+      }
+
+      // 1c. Actualizar costo en product_costs si cambió
+      if (data.cost !== undefined && data.cost >= 0) {
+        const now = new Date().toISOString();
+        const { data: currentCost } = await supabase
+          .from('product_costs')
+          .select('id, cost')
+          .eq('product_id', productoId)
+          .is('effective_to', null)
+          .order('effective_from', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        const costChanged = !currentCost || currentCost.cost !== data.cost;
+
+        if (costChanged) {
+          if (currentCost) {
+            await supabase
+              .from('product_costs')
+              .update({ effective_to: now })
+              .eq('id', currentCost.id);
+          }
+          const { error: costError } = await supabase
+            .from('product_costs')
+            .insert({
+              product_id: productoId,
+              cost: data.cost,
+              effective_from: now,
+              effective_to: null,
+            });
+          if (costError) throw costError;
+        }
+      }
       
       // 2. Imágenes se manejan a través de formData (no requiere ref)
       

--- a/src/components/inventario/productos/id/tabs/PreciosTab.tsx
+++ b/src/components/inventario/productos/id/tabs/PreciosTab.tsx
@@ -261,27 +261,8 @@ const PreciosTab: React.FC<PreciosTabProps> = ({ producto }) => {
       
       if (newPriceError) throw newPriceError;
       
-      // 3. Actualizar el precio de referencia en la tabla de productos
-      const { error: updateError } = await supabase
-        .from('products')
-        .update({
-          price: priceValue,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', producto.id)
-        .eq('organization_id', organization?.id);
-      
-      if (updateError) throw updateError;
-      
-      // 3. Actualizar registro en product_variants si es principal
-      const { error: variantError } = await supabase
-        .from('product_variants')
-        .update({ price: priceValue })
-        .eq('product_id', producto.id)
-        .eq('is_primary', true);
-      
-      // No bloqueamos por error en variantes
-      if (variantError) console.error('Error al actualizar variante:', variantError);
+      // El precio de referencia ya se guardó en product_prices en el paso anterior
+      // No es necesario actualizar la tabla products ya que no tiene columna price
       
       toast({
         title: "Precio actualizado",

--- a/src/components/organization/CreateOrganizationForm.tsx
+++ b/src/components/organization/CreateOrganizationForm.tsx
@@ -253,6 +253,7 @@ export default function CreateOrganizationForm({ onSuccess, onCancel, defaultEma
         state: formData.state,
         country: formData.country,
         country_code: formData.countryCode,
+        municipality_id: formData.municipalityId || null,
         postal_code: formData.postalCode,
         tax_id: formData.taxId,
         nit: formData.nit,

--- a/src/components/organization/InvitationsTab.tsx
+++ b/src/components/organization/InvitationsTab.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@/lib/supabase/config';
 import { getRoleInfoById, getRoleIdByCode, formatRolesForDropdown, roleDisplayMap } from '@/utils/roleUtils';
 import { InvitationsSkeleton } from './OrganizationSkeletons';
 import { useTranslations } from 'next-intl';
+import { EmailConfirmedGate, EmailConfirmedWarning } from '@/components/auth/EmailConfirmedGate';
 
 interface InvitationProps {
   id: string;
@@ -670,6 +671,7 @@ export default function InvitationsTab({ orgId }: { orgId: number }) {
             </div>
           )}
           
+          <EmailConfirmedWarning message="Debes confirmar tu correo electrónico para invitar nuevos usuarios." />
           <form onSubmit={handleSendInvitation} className="space-y-4 mt-4 bg-gray-50 dark:bg-gray-800/50 p-4 rounded-lg">
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -711,13 +713,15 @@ export default function InvitationsTab({ orgId }: { orgId: number }) {
             </div>
             
             <div className="pt-2">
-              <button
-                type="submit"
-                disabled={sendingInvitation || !!(maxUsers && (currentMemberCount + pendingInvitationsCount) >= maxUsers)}
-                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {sendingInvitation ? t('sending') : t('sendInvitation')}
-              </button>
+              <EmailConfirmedGate>
+                <button
+                  type="submit"
+                  disabled={sendingInvitation || !!(maxUsers && (currentMemberCount + pendingInvitationsCount) >= maxUsers)}
+                  className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {sendingInvitation ? t('sending') : t('sendInvitation')}
+                </button>
+              </EmailConfirmedGate>
             </div>
           </form>
         </div>

--- a/src/components/organization/ManageOrganizationsTab.tsx
+++ b/src/components/organization/ManageOrganizationsTab.tsx
@@ -4,6 +4,17 @@ import { useState, lazy, Suspense } from 'react';
 import { supabase } from '@/lib/supabase/config';
 import OrganizationList from './OrganizationList';
 import { useTranslations } from 'next-intl';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+import { Loader2, AlertTriangle } from 'lucide-react';
 
 const CreateOrganizationForm = lazy(() => import('./CreateOrganizationForm'));
 
@@ -11,19 +22,25 @@ export default function ManageOrganizationsTab() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [error, setError] = useState('');
   const t = useTranslations('org.manageOrgs');
+  const [orgToDelete, setOrgToDelete] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [refetchKey, setRefetchKey] = useState(0);
 
   const handleCreateSuccess = () => {
     setShowCreateForm(false);
-    window.location.reload();
+    setRefetchKey(k => k + 1);
   };
 
-  const handleDeleteOrganization = async (orgId: number) => {
-    if (!window.confirm(t('confirmDelete'))) {
-      return;
-    }
+  const handleDeleteOrganization = (orgId: number) => {
+    setOrgToDelete(orgId);
+  };
+
+  const confirmDelete = async () => {
+    if (!orgToDelete) return;
+    setDeleting(true);
+    setError('');
 
     try {
-      // Check if user is admin of the organization
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) throw new Error(t('noSession'));
 
@@ -31,7 +48,7 @@ export default function ManageOrganizationsTab() {
         .from('organization_members')
         .select('role_id, is_super_admin')
         .eq('user_id', session.user.id)
-        .eq('organization_id', orgId)
+        .eq('organization_id', orgToDelete)
         .single();
 
       if (memberError) throw memberError;
@@ -39,18 +56,40 @@ export default function ManageOrganizationsTab() {
         throw new Error(t('noPermissionsDelete'));
       }
 
-      // Delete organization (this will cascade delete branches, organization_members, etc.)
-      // Note: manager_id references in branches will be automatically set to NULL due to FK constraint
       const { error: deleteError } = await supabase
         .from('organizations')
         .delete()
-        .eq('id', orgId);
+        .eq('id', orgToDelete);
 
       if (deleteError) throw deleteError;
 
-      window.location.reload();
+      // Verificar si el usuario aún tiene organizaciones
+      const { data: remainingOrgs, error: orgCheckError } = await supabase
+        .from('organization_members')
+        .select('organization_id')
+        .eq('user_id', session.user.id);
+
+      if (orgCheckError) throw orgCheckError;
+
+      if (!remainingOrgs || remainingOrgs.length === 0) {
+        // No tiene más organizaciones, redirigir a selección de organización
+        localStorage.removeItem('currentOrganizationId');
+        localStorage.removeItem('currentOrganizationName');
+        localStorage.removeItem('currentOrganizationType');
+        window.location.href = '/auth/select-organization';
+      } else {
+        // Si la org eliminada era la actual, cambiar a otra
+        const currentOrgId = localStorage.getItem('currentOrganizationId');
+        if (currentOrgId && parseInt(currentOrgId) === orgToDelete) {
+          localStorage.setItem('currentOrganizationId', String(remainingOrgs[0].organization_id));
+        }
+        setRefetchKey(k => k + 1);
+      }
     } catch (err: any) {
       setError(err.message);
+    } finally {
+      setDeleting(false);
+      setOrgToDelete(null);
     }
   };
 
@@ -102,9 +141,43 @@ export default function ManageOrganizationsTab() {
             onDelete={handleDeleteOrganization}
             filterActive={false}
             showFilters={true}
+            refetchKey={refetchKey}
           />
         </div>
       )}
+
+      <AlertDialog open={orgToDelete !== null} onOpenChange={(open) => { if (!open && !deleting) setOrgToDelete(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-red-600" />
+              {t('confirmDelete')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('confirmDeleteDescription') || 'Esta acción eliminará la organización, sus sucursales y todos los datos asociados. No se puede deshacer.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting} onClick={() => setOrgToDelete(null)}>
+              {t('cancel') || 'Cancelar'}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={deleting}
+              onClick={confirmDelete}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              {deleting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  {t('deleting') || 'Eliminando...'}
+                </>
+              ) : (
+                t('delete') || 'Eliminar'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/organization/OrganizationList.tsx
+++ b/src/components/organization/OrganizationList.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState, useEffect, ReactElement, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase/config';
 import { OrganizationListSkeleton } from './OrganizationSkeletons';
 import ChangePlanModal from './ChangePlanModal';
 import { useTranslations } from 'next-intl';
+import { cambiarOrganizacionActiva } from '@/lib/hooks/useOrganization';
 
 type ProfileData = {
   organization_id: number | null;
@@ -40,9 +42,11 @@ interface OrganizationListProps {
   onDelete?: (orgId: number) => void;
   filterActive?: boolean; // Si es true, solo muestra organizaciones activas
   showFilters?: boolean; // Si es true, muestra la barra de filtros
+  refetchKey?: number; // Cambiar este valor fuerza un re-fetch sin recargar la página
 }
 
-export default function OrganizationList({ showActions = false, onDelete, filterActive = false, showFilters = false }: OrganizationListProps): ReactElement {
+export default function OrganizationList({ showActions = false, onDelete, filterActive = false, showFilters = false, refetchKey }: OrganizationListProps): ReactElement {
+  const router = useRouter();
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -88,7 +92,7 @@ export default function OrganizationList({ showActions = false, onDelete, filter
 
   useEffect(() => {
     fetchUserOrganizations();
-  }, []);
+  }, [refetchKey]);
 
   const fetchUserOrganizations = async () => {
     try {
@@ -227,20 +231,34 @@ export default function OrganizationList({ showActions = false, onDelete, filter
   
   const handleSelectOrganization = async (orgId: number) => {
     try {
-      // Get current user session
+      const selectedOrg = organizations.find(o => o.id === orgId);
+      if (!selectedOrg) return;
+
+      // Actualizar localStorage y limpiar estado de la org anterior (sin recargar)
+      cambiarOrganizacionActiva(
+        { id: selectedOrg.id, name: selectedOrg.name },
+        { reload: false }
+      );
+
+      // Actualizar last_org_id en la BD
       const { data: { session } } = await supabase.auth.getSession();
-      if (!session) throw new Error(t('noSession'));
+      if (session) {
+        await supabase
+          .from('profiles')
+          .update({ last_org_id: orgId })
+          .eq('id', session.user.id);
+      }
 
-      // Update user's organization
-      const { error } = await supabase
-        .from('profiles')
-        .update({ last_org_id: orgId })
-        .eq('id', session.user.id);
+      // Actualizar UI localmente: marcar la org seleccionada como actual
+      setOrganizations(prevOrgs =>
+        prevOrgs.map(org => ({ ...org, is_current: org.id === orgId }))
+      );
 
-      if (error) throw error;
+      // Notificar al resto de la app (AppLayout, header, etc.)
+      window.dispatchEvent(new Event('organization-changed'));
 
-      // Reload page to reflect changes
-      window.location.reload();
+      // Navegación suave al dashboard (re-monta componentes con el nuevo org)
+      router.push('/app');
     } catch (err: any) {
       console.error('Error selecting organization:', err);
       setError(err.message);

--- a/src/components/organization/PlanTab.tsx
+++ b/src/components/organization/PlanTab.tsx
@@ -33,6 +33,7 @@ import { PlanSkeleton } from './OrganizationSkeletons';
 import CancelSubscriptionModal from '@/components/subscription/CancelSubscriptionModal';
 import PaymentMethodCard from './PaymentMethodCard';
 import { useTranslations } from 'next-intl';
+import { EmailConfirmedGate } from '@/components/auth/EmailConfirmedGate';
 
 // Mapa de iconos para módulos (igual que en modulos/page.tsx)
 const moduleIcons: Record<string, LucideIcon> = {
@@ -679,13 +680,15 @@ export default function PlanTab({ orgId }: PlanTabProps) {
                 {/* Botones adicionales de gestión */}
                 <div className="flex flex-wrap items-center gap-2 mt-3 pt-3 border-t border-gray-200">
                     {subscription?.stripe_customer_id && (
-                      <button
-                        onClick={handleOpenBillingPortal}
-                        className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-                      >
-                        <DocumentTextIcon className="w-4 h-4 mr-1" />
-                        {t('billingPortal')}
-                      </button>
+                      <EmailConfirmedGate>
+                        <button
+                          onClick={handleOpenBillingPortal}
+                          className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+                        >
+                          <DocumentTextIcon className="w-4 h-4 mr-1" />
+                          {t('billingPortal')}
+                        </button>
+                      </EmailConfirmedGate>
                     )}
                     {subscription?.status === 'canceled' ? (
                       <button

--- a/src/components/profile/SeguridadSection.tsx
+++ b/src/components/profile/SeguridadSection.tsx
@@ -5,6 +5,7 @@ import { User } from '@supabase/supabase-js';
 import { supabase, updatePassword } from '@/lib/supabase/config';
 import { Lock, Key, RefreshCcw, Shield, AlertTriangle, Eye, EyeOff } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { EmailConfirmedGate, EmailConfirmedWarning } from '@/components/auth/EmailConfirmedGate';
 
 interface MfaMethod {
   id: string;
@@ -217,12 +218,14 @@ export default function SeguridadSection({ user, mfaMethods, onMfaUpdated }: Seg
               </p>
             </div>
           </div>
-          <button
-            onClick={() => setShowPasswordModal(true)}
-            className="px-3 py-1.5 text-sm rounded-md bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50"
-          >
-            Cambiar
-          </button>
+          <EmailConfirmedGate>
+            <button
+              onClick={() => setShowPasswordModal(true)}
+              className="px-3 py-1.5 text-sm rounded-md bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50"
+            >
+              Cambiar
+            </button>
+          </EmailConfirmedGate>
         </div>
         
         {/* Modal para cambiar contraseña */}
@@ -232,6 +235,7 @@ export default function SeguridadSection({ user, mfaMethods, onMfaUpdated }: Seg
               <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4">
                 Cambiar contraseña
               </h3>
+              <EmailConfirmedWarning message="Debes confirmar tu correo electrónico para cambiar la contraseña." />
               
               <form onSubmit={handlePasswordChange} className="space-y-4">
                 <div>

--- a/src/components/subscription/BillingTab.tsx
+++ b/src/components/subscription/BillingTab.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircleIcon,
   ExclamationTriangleIcon
 } from '@heroicons/react/24/outline';
+import { EmailConfirmedGate } from '@/components/auth/EmailConfirmedGate';
 
 interface Invoice {
   id: string;
@@ -255,14 +256,16 @@ export default function BillingTab({ orgId }: BillingTabProps) {
             <h3 className="text-sm font-medium text-blue-800">Portal de Facturación de Stripe</h3>
             <p className="text-sm text-blue-600">Gestiona tus facturas, métodos de pago y suscripción</p>
           </div>
-          <button
-            onClick={handleOpenBillingPortal}
-            disabled={actionLoading === 'portal'}
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
-          >
-            {actionLoading === 'portal' ? 'Abriendo...' : 'Abrir Portal'}
-            <ArrowTopRightOnSquareIcon className="ml-2 h-4 w-4" />
-          </button>
+          <EmailConfirmedGate>
+            <button
+              onClick={handleOpenBillingPortal}
+              disabled={actionLoading === 'portal'}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            >
+              {actionLoading === 'portal' ? 'Abriendo...' : 'Abrir Portal'}
+              <ArrowTopRightOnSquareIcon className="ml-2 h-4 w-4" />
+            </button>
+          </EmailConfirmedGate>
         </div>
       </div>
 

--- a/src/hooks/useEmailConfirmed.ts
+++ b/src/hooks/useEmailConfirmed.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase/config';
+
+/**
+ * Hook para verificar si el correo del usuario actual está confirmado.
+ * Se usa para restringir acciones sensibles (cambiar contraseña, facturación,
+ * invitar usuarios) a solo cuentas con email confirmado.
+ */
+export function useEmailConfirmed() {
+  const [confirmed, setConfirmed] = useState(true);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const check = async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (mounted) setConfirmed(!!user?.email_confirmed_at);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    check();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'USER_UPDATED') {
+        setConfirmed(!!session?.user?.email_confirmed_at);
+      }
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return { confirmed, loading };
+}

--- a/src/lib/services/aiActionsService.ts
+++ b/src/lib/services/aiActionsService.ts
@@ -417,11 +417,34 @@ class AIActionsService {
   }
 
   private async updateProductPrice(data: Record<string, any>, organizationId: number) {
+    const now = new Date().toISOString();
+
+    // Cerrar precio vigente actual
+    const { data: currentPrice } = await supabase
+      .from('product_prices')
+      .select('id')
+      .eq('product_id', data.product_id)
+      .is('effective_to', null)
+      .order('effective_from', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (currentPrice) {
+      await supabase
+        .from('product_prices')
+        .update({ effective_to: now })
+        .eq('id', currentPrice.id);
+    }
+
+    // Insertar nuevo precio
     const { error } = await supabase
-      .from('products')
-      .update({ price: data.new_price })
-      .eq('id', data.product_id)
-      .eq('organization_id', organizationId);
+      .from('product_prices')
+      .insert({
+        product_id: data.product_id,
+        price: data.new_price,
+        effective_from: now,
+        effective_to: null,
+      });
 
     if (error) throw new Error(error.message);
     return { success: true, message: `Precio actualizado a $${data.new_price}` };

--- a/src/lib/supabase/config.ts
+++ b/src/lib/supabase/config.ts
@@ -20,28 +20,50 @@ const getCookie = (name: string): string | null => {
   return null;
 }
 
-// Función para establecer una cookie
+// Función para establecer una cookie (con soporte de chunks para cookies grandes)
 const setCookie = (name: string, value: string, maxAge: number = 604800) => {
   if (typeof document === 'undefined') return;
   
-  // La cookie de autenticación de Supabase necesita estar disponible para JavaScript
   const isAuthCookie = name.includes('-auth-token');
   const isProduction = process.env.NODE_ENV === 'production';
   const cookieDomain = isProduction ? '; domain=.goadmin.io' : '';
+  const encodedValue = encodeURIComponent(value);
   
-  document.cookie = `${name}=${encodeURIComponent(value)};path=/;max-age=${maxAge};SameSite=Lax${!isAuthCookie ? ';HttpOnly' : ''}${isProduction ? ';Secure' : ''}${cookieDomain}`;
+  // Limpiar chunks anteriores si existían
+  for (let i = 0; i < 20; i++) {
+    document.cookie = `${name}.${i}=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;SameSite=Lax${cookieDomain}`;
+  }
+  
+  if (encodedValue.length < 3600) {
+    document.cookie = `${name}=${encodedValue};path=/;max-age=${maxAge};SameSite=Lax${!isAuthCookie ? ';HttpOnly' : ''}${isProduction ? ';Secure' : ''}${cookieDomain}`;
+  } else {
+    // Dividir en chunks para cookies grandes
+    const CHUNK_SIZE = 3500;
+    let chunkIndex = 0;
+    let offset = 0;
+    while (offset < encodedValue.length) {
+      const chunk = encodedValue.substring(offset, offset + CHUNK_SIZE);
+      document.cookie = `${name}.${chunkIndex}=${chunk};path=/;max-age=${maxAge};SameSite=Lax${!isAuthCookie ? ';HttpOnly' : ''}${isProduction ? ';Secure' : ''}${cookieDomain}`;
+      offset += CHUNK_SIZE;
+      chunkIndex++;
+    }
+    console.log(`🍪 [SETCOOKIE] Cookie chunked: ${name} (${chunkIndex} chunks, ${encodedValue.length} bytes)`);
+  }
 }
 
 // Función para eliminar una cookie
 const removeCookie = (name: string) => {
   if (typeof document === 'undefined') return;
   
-  // La cookie de autenticación de Supabase necesita estar disponible para JavaScript
   const isAuthCookie = name.includes('-auth-token');
   const isProduction = process.env.NODE_ENV === 'production';
   const cookieDomain = isProduction ? '; domain=.goadmin.io' : '';
   
   document.cookie = `${name}=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;SameSite=Lax${!isAuthCookie ? ';HttpOnly' : ''}${isProduction ? ';Secure' : ''}${cookieDomain}`;
+  // Limpiar chunks .0, .1, .2...
+  for (let i = 0; i < 20; i++) {
+    document.cookie = `${name}.${i}=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;SameSite=Lax${cookieDomain}`;
+  }
 }
 
 // Creación del cliente de Supabase para el navegador
@@ -94,25 +116,40 @@ export const createSupabaseClient = () => {
             console.log('💾 [STORAGE] Guardado en localStorage:', key);
             
             // También guardar en cookies para que el middleware pueda leerlo
-            // Usar secure en producción, no secure en desarrollo
             const secureFlag = window.location.protocol === 'https:' ? '; Secure' : '';
             const isProduction = process.env.NODE_ENV === 'production';
             const cookieDomain = isProduction ? '; domain=.goadmin.io' : '';
-            const cookieValue = `${key}=${encodeURIComponent(value)}; path=/; max-age=2592000; SameSite=Lax${secureFlag}${cookieDomain}`;
-            document.cookie = cookieValue;
-            console.log('🍪 [STORAGE] Guardado en cookie:', key, 'con flags:', secureFlag, cookieDomain);
+            const encodedValue = encodeURIComponent(value);
+            
+            // Limpiar chunks anteriores si existían
+            document.cookie = `${key}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax${cookieDomain}`;
+            for (let i = 0; i < 20; i++) {
+              document.cookie = `${key}.${i}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax${cookieDomain}`;
+            }
+            
+            // Si el valor codificado cabe en una sola cookie (< 3600 bytes), usar cookie simple
+            if (encodedValue.length < 3600) {
+              document.cookie = `${key}=${encodedValue}; path=/; max-age=2592000; SameSite=Lax${secureFlag}${cookieDomain}`;
+              console.log('🍪 [STORAGE] Guardado en cookie simple:', key);
+            } else {
+              // Dividir en chunks de ~3500 bytes para no exceder el límite de 4KB por cookie
+              const CHUNK_SIZE = 3500;
+              let chunkIndex = 0;
+              let offset = 0;
+              while (offset < encodedValue.length) {
+                const chunk = encodedValue.substring(offset, offset + CHUNK_SIZE);
+                document.cookie = `${key}.${chunkIndex}=${chunk}; path=/; max-age=2592000; SameSite=Lax${secureFlag}${cookieDomain}`;
+                offset += CHUNK_SIZE;
+                chunkIndex++;
+              }
+              console.log(`🍪 [STORAGE] Guardado en cookie chunked: ${key} (${chunkIndex} chunks, ${encodedValue.length} bytes)`);
+            }
             
             // Verificar que la cookie se estableció correctamente
             setTimeout(() => {
               const cookies = document.cookie.split(';');
-              const cookieExists = cookies.some(c => c.trim().startsWith(`${key}=`));
+              const cookieExists = cookies.some(c => c.trim().startsWith(`${key}=`) || c.trim().startsWith(`${key}.0=`));
               console.log(`🔍 [STORAGE] Verificación cookie ${key}:`, cookieExists ? 'EXISTE' : 'NO EXISTE');
-              
-              if (!cookieExists) {
-                console.warn(`⚠️ [STORAGE] Cookie ${key} no se estableció correctamente, reintentando...`);
-                // Reintentar sin flags adicionales
-                document.cookie = `${key}=${encodeURIComponent(value)}; path=/`;
-              }
             }, 100);
           }
         },
@@ -122,11 +159,15 @@ export const createSupabaseClient = () => {
             localStorage.removeItem(key);
             console.log('💾 [STORAGE] Eliminado de localStorage:', key);
             
-            // Eliminar de cookies
+            // Eliminar de cookies (cookie simple + chunks)
             const isProduction = process.env.NODE_ENV === 'production';
             const cookieDomain = isProduction ? '; domain=.goadmin.io' : '';
             document.cookie = `${key}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax${cookieDomain}`;
-            console.log('🍪 [STORAGE] Eliminado de cookie:', key);
+            // Limpiar chunks .0, .1, .2...
+            for (let i = 0; i < 20; i++) {
+              document.cookie = `${key}.${i}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax${cookieDomain}`;
+            }
+            console.log('🍪 [STORAGE] Eliminado de cookie (incluyendo chunks):', key);
           }
         },
       },
@@ -231,36 +272,41 @@ export const ensureSessionSynced = async (): Promise<boolean> => {
     localStorage.setItem(storageKey, JSON.stringify(sessionToken));
     console.log('💾 [SESSION] Sesión guardada en localStorage');
     
-    // Guardar en cookies de forma más agresiva
+    // Guardar en cookies con soporte de chunks para tokens grandes
     const cookieValue = encodeURIComponent(JSON.stringify(sessionToken));
     const secureFlag = window.location.protocol === 'https:' ? '; Secure' : '';
+    const isProduction = process.env.NODE_ENV === 'production';
+    const cookieDomain = isProduction ? '; domain=.goadmin.io' : '';
     
-    // Probar múltiples formatos de cookie
-    const cookieFormats = [
-      `${storageKey}=${cookieValue}; path=/; max-age=604800; SameSite=Lax${secureFlag}`,
-      `${storageKey}=${cookieValue}; path=/; SameSite=Lax`,
-      `${storageKey}=${cookieValue}; path=/`
-    ];
+    // Limpiar cookie simple y chunks anteriores
+    document.cookie = `${storageKey}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax${cookieDomain}`;
+    for (let i = 0; i < 20; i++) {
+      document.cookie = `${storageKey}.${i}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax${cookieDomain}`;
+    }
     
-    for (let i = 0; i < cookieFormats.length; i++) {
-      document.cookie = cookieFormats[i];
-      console.log(`🍪 [SESSION] Intentando formato cookie ${i + 1}:`, cookieFormats[i].substring(0, 100) + '...');
-      
-      // Verificar si se estableció
-      setTimeout(() => {
-        const cookies = document.cookie.split(';');
-        const exists = cookies.some(c => c.trim().startsWith(`${storageKey}=`));
-        if (exists) {
-          console.log(`✅ [SESSION] Cookie establecida con formato ${i + 1}`);
-        }
-      }, 50);
+    if (cookieValue.length < 3600) {
+      // Cookie simple para valores pequeños
+      document.cookie = `${storageKey}=${cookieValue}; path=/; max-age=604800; SameSite=Lax${secureFlag}${cookieDomain}`;
+      console.log('🍪 [SESSION] Cookie simple establecida');
+    } else {
+      // Dividir en chunks para valores grandes
+      const CHUNK_SIZE = 3500;
+      let chunkIndex = 0;
+      let offset = 0;
+      while (offset < cookieValue.length) {
+        const chunk = cookieValue.substring(offset, offset + CHUNK_SIZE);
+        document.cookie = `${storageKey}.${chunkIndex}=${chunk}; path=/; max-age=604800; SameSite=Lax${secureFlag}${cookieDomain}`;
+        offset += CHUNK_SIZE;
+        chunkIndex++;
+      }
+      console.log(`🍪 [SESSION] Cookie chunked establecida: ${chunkIndex} chunks, ${cookieValue.length} bytes`);
     }
     
     // Verificación final después de un delay
     return new Promise((resolve) => {
       setTimeout(() => {
         const cookies = document.cookie.split(';');
-        const exists = cookies.some(c => c.trim().startsWith(`${storageKey}=`));
+        const exists = cookies.some(c => c.trim().startsWith(`${storageKey}=`) || c.trim().startsWith(`${storageKey}.0=`));
         console.log('🔍 [SESSION] Verificación final de cookie:', exists ? 'ÉXITO' : 'FALLÓ');
         resolve(exists);
       }, 200);
@@ -282,12 +328,13 @@ export const signInWithEmail = async (email: string, password: string) => {
   }
 
   if (result.data.session) {
-    const { access_token, refresh_token, expires_at } = result.data.session;
+    const { access_token, refresh_token, expires_at, user } = result.data.session;
   
     const tokenPayload = JSON.stringify({
       access_token,
       refresh_token,
-      expires_at
+      expires_at,
+      user
     });
   
     const projectRef = getProjectRef(); // or hardcode your Supabase project ref
@@ -366,6 +413,10 @@ export const signOut = async () => {
     // Limpiar cookie específica del proyecto usando la referencia dinámica
     if (projectRef) {
       document.cookie = `sb-${projectRef}-auth-token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax`;
+      // Limpiar chunks .0, .1, .2...
+      for (let i = 0; i < 20; i++) {
+        document.cookie = `sb-${projectRef}-auth-token.${i}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax`;
+      }
     }
     
     // También limpiar la cookie CSRF

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -299,8 +299,24 @@ async function checkModuleAccess(request: NextRequest, pathname: string): Promis
       return null;
     }
 
-    // Obtener información del usuario desde las cookies
-    const authCookie = request.cookies.get('sb-jgmgphmzusbluqhuqihj-auth-token');
+    // Obtener información del usuario desde las cookies (con soporte de chunks)
+    const authCookieName = 'sb-jgmgphmzusbluqhuqihj-auth-token';
+    let authCookie = request.cookies.get(authCookieName);
+    if (!authCookie) {
+      // Buscar cookies chunked (.0, .1, .2...)
+      const chunk0 = request.cookies.get(`${authCookieName}.0`);
+      if (chunk0) {
+        let fullValue = chunk0.value;
+        let i = 1;
+        while (true) {
+          const chunk = request.cookies.get(`${authCookieName}.${i}`);
+          if (!chunk) break;
+          fullValue += chunk.value;
+          i++;
+        }
+        authCookie = { name: authCookieName, value: fullValue };
+      }
+    }
     if (!authCookie?.value) {
       return NextResponse.redirect(new URL('/auth/login', request.url));
     }


### PR DESCRIPTION
resumen de pago con cupón, UX sin recarga en mis organizaciones y fixes varios
 
- Crear componente PriceSummary para mostrar resumen de pago con descuento de cupón
- Integrar PriceSummary en SubscriptionStep y PaymentMethodStep
- Hacer responsive el input del cupón en móvil (flex-col sm:flex-row)
- Pasar validatedCoupon entre pasos del signup via formData
- Eliminar window.location.reload() al crear/eliminar organización (usar refetchKey)
- Corregir badge 'actual': actualizar localStorage al cambiar organización
- Cambiar organización sin recargar: usar cambiarOrganizacionActiva + router.push
- Agregar listener 'organization-changed' en AppLayout para actualizar header
- Fix: agregar municipality_id al crear organización en signup y CreateOrganizationForm