### PR TITLE
Main

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:win": "cross-env NODE_OPTIONS=--max-http-header-size=32768 next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
           }
         },
         persistSession: true,
-        autoRefreshToken: true,
+        autoRefreshToken: false,
         detectSessionInUrl: false
       }
     }
@@ -101,11 +101,10 @@ export async function GET(request: NextRequest) {
           
           const hasOrganization = await checkUserOrganization(supabase, user.id);
           
-          // Eliminar cookie de sesión chunked de Supabase (evita error 431 por headers too large)
-          const projectRef = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL!).hostname.split('.')[0];
-          pendingCookies.delete(`sb-${projectRef}-auth-token`);
+          // NO eliminar la cookie sb-${projectRef}-auth-token: el cliente la necesita para persistir la sesión
+          // La cookie go-admin-oauth-session sirve como fallback para hidratar en select-organization
           
-          // Redirigir sin tokens en URL (la cookie go-admin-oauth-session se usa para hidratar)
+          // Redirigir sin tokens en URL (la cookie go-admin-oauth-session se usa como fallback)
           if (hasOrganization) {
             return redirectWithCookies('/auth/select-organization?dest=' + encodeURIComponent(next));
           } else {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -91,7 +91,7 @@ export async function GET(request: NextRequest) {
         
         // Para OAuth (Google login), crear o actualizar perfil
         if (user.app_metadata?.provider === 'google') {
-          // Cookie pequeña para hidratación client-side
+          // Cookie para hidratación client-side (la página select-organization la lee como fallback)
           pendingCookies.set('go-admin-oauth-session', JSON.stringify({
             access_token: data.session.access_token,
             refresh_token: data.session.refresh_token,
@@ -101,20 +101,15 @@ export async function GET(request: NextRequest) {
           
           const hasOrganization = await checkUserOrganization(supabase, user.id);
           
-          // Eliminar cookie de sesión completa DESPUÉS de DB ops (evita sesión parcial en el cliente)
+          // Eliminar cookie de sesión chunked de Supabase (evita error 431 por headers too large)
           const projectRef = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL!).hostname.split('.')[0];
           pendingCookies.delete(`sb-${projectRef}-auth-token`);
           
-          // Pasar tokens por URL params para hidratación client-side (más confiable que cookies)
-          const oauthParam = encodeURIComponent(JSON.stringify({
-            at: data.session.access_token,
-            rt: data.session.refresh_token,
-          }));
-          
+          // Redirigir sin tokens en URL (la cookie go-admin-oauth-session se usa para hidratar)
           if (hasOrganization) {
-            return redirectWithCookies('/auth/select-organization?_oauth=' + oauthParam + '&dest=' + encodeURIComponent(next));
+            return redirectWithCookies('/auth/select-organization?dest=' + encodeURIComponent(next));
           } else {
-            return redirectWithCookies('/auth/select-organization?_oauth=' + oauthParam);
+            return redirectWithCookies('/auth/select-organization');
           }
         } else {
           // Para confirmación de email, verificar si es una invitación


### PR DESCRIPTION
fix: evitar rotacion de refresh token en callback OAuth
 
- autoRefreshToken: false en cliente del servidor del callback
- No eliminar cookie sb-auth-token para que el cliente persista la sesion
- El refresh token ya no se invalida antes de que el cliente lo use