### PR TITLE
corregir flujo de invitación que invalidaba token y no creaba membresía

### DIFF
--- a/docs/track-stock-feature.md
+++ b/docs/track-stock-feature.md
@@ -1,0 +1,196 @@
+# Feature: No registrar stock en productos
+
+## Objetivo
+
+Permitir que ciertos productos (de difícil control de inventario) se marquen como **"no registrar stock"** mediante un checkbox **editable en cualquier momento** desde el formulario de creación o edición de producto. Estos productos:
+- **No tienen control de stock** (se asume inventario infinito)
+- **Se pueden vender sin validación** de stock disponible
+- **No se les descuenta ni suma stock** en ventas, compras, transferencias ni movimientos
+- **No aparecen en reportes de inventario** ni alertas de stock mínimo
+- **En la tienda web** se muestran como "Siempre disponible"
+- **El cambio es reversible**: se puede activar/desactivar en cualquier momento desde la edición del producto
+
+### Editabilidad de `track_stock`
+
+El campo `track_stock` se puede cambiar en cualquier momento:
+
+| Escenario | Comportamiento |
+|-----------|---------------|
+| **Crear producto** con `track_stock = false` | No se crea sección de stock inicial. Producto vendible inmediatamente |
+| **Editar producto** de `true` → `false` | Se oculta sección de stock. Los `stock_levels` existentes se mantienen pero se ignoran. Advertencia: "Al desactivar el control de stock, los niveles actuales se ignorarán" |
+| **Editar producto** de `false` → `true` | Se muestra sección de stock. Advertencia: "Al activar el control de stock, deberás registrar el stock inicial por sucursal" |
+| **Variantes** | Cada variante tiene su propio `track_stock` independiente, hereda del padre al crearse pero se puede cambiar individualmente |
+
+## Comportamiento por módulo
+
+### POS y ventas (ERP)
+- **Productos con `track_stock = true`**: El POS ya descuenta stock en checkout. Se mantiene el comportamiento actual.
+- **Productos con `track_stock = false`**: Se omiten de la validación de stock y de la reserva/descuento de `stock_levels`. Se venden sin restricción.
+
+### Compras (ERP)
+- **Productos con `track_stock = true`**: Al recepcionar factura de compra, se suma stock (`stock_movements` + `stock_levels`). Comportamiento actual.
+- **Productos con `track_stock = false`**: No se generan movimientos ni se actualiza `stock_levels`.
+
+### Transferencias (ERP)
+- **Productos con `track_stock = true`**: Generan movimientos de salida/entrada y actualizan `stock_levels`. Comportamiento actual.
+- **Productos con `track_stock = false`**: Se bloquean o advierten al intentar transferir (no tiene sentido transferir algo sin stock).
+
+### Inventario y reportes (ERP)
+- **Productos con `track_stock = false`**: Se excluyen de:
+  - Niveles de stock (`stock_levels`)
+  - Alertas de stock mínimo y agotados
+  - Estadísticas de valor de inventario
+  - Exportación a CSV de stock
+  - Movimientos de stock
+
+### Tienda web (goadmin-websites)
+- **Productos con `track_stock = false`**:
+  - En validación de orden: se excluyen del chequeo de stock disponible
+  - En reserva de stock: no se reserva stock
+  - En UI: se muestra badge "Siempre disponible" en lugar de cantidad
+  - Botón de compra siempre habilitado
+
+---
+
+## Base de datos
+
+### Migración
+
+```sql
+ALTER TABLE products ADD COLUMN track_stock boolean DEFAULT true NOT NULL;
+```
+
+- `true` = comportamiento actual (trackea stock por sucursal)
+- `false` = no trackea, stock infinito, sin validación ni movimientos
+
+### Tabla `products` (campos relevantes después de la migración)
+
+| Columna | Tipo | Default | Descripción |
+|---------|------|---------|-------------|
+| `id` | integer | auto | PK |
+| `organization_id` | integer | - | FK organización |
+| `sku` | text | - | SKU único |
+| `name` | text | - | Nombre |
+| `track_stock` | boolean | `true` | Si false, no se controla stock |
+| `status` | text | `'active'` | Estado del producto |
+| `is_parent` | boolean | `false` | Si tiene variantes |
+| `parent_product_id` | integer | null | FK producto padre (variantes) |
+
+### Tabla `stock_levels` (sin cambios)
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| `product_id` | integer | FK producto |
+| `branch_id` | integer | FK sucursal |
+| `qty_on_hand` | numeric | Stock disponible |
+| `qty_reserved` | numeric | Stock reservado |
+| `avg_cost` | numeric | Costo promedio |
+| `min_level` | numeric | Nivel mínimo |
+
+> Los productos con `track_stock = false` simplemente no tendrán registros en `stock_levels`, o si los tienen, serán ignorados.
+
+---
+
+## Archivos a modificar
+
+### ERP (go-admin-erp)
+
+#### 1. Formularios de producto
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/components/inventario/productos/nuevo/InformacionBasica.tsx` | Agregar checkbox "No registrar stock" con tooltip: "Para productos de difícil control de inventario. Se podrán vender sin validar stock disponible." |
+| `src/components/inventario/productos/nuevo/NuevoProductoForm.tsx` | Leer estado del checkbox, enviar `track_stock` al crear producto. Si `false`, ocultar sección `Inventario.tsx` y no crear registros en `stock_levels` |
+| `src/components/inventario/productos/nuevo/Inventario.tsx` | Recibir prop `trackStock`. Si `false`, ocultar UI de stock por sucursal |
+| `src/components/inventario/productos/editar/FormularioEdicionProducto.tsx` | Cargar `track_stock` desde DB. Mostrar checkbox. Si `false`, ocultar pestaña/section de stock. Guardar cambios |
+
+#### 2. Inventario y reportes
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/lib/services/stockService.ts` | En `getStockLevels`, `getStockLevelsSimple`, `getStockStats`, `exportStockToCSV`: filtrar `products.track_stock = true`. En `getStockMovements`: filtrar productos con `track_stock = true` |
+
+#### 3. POS
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/components/pos/types.ts` | Agregar `track_stock?: boolean` a interface `Product` |
+| `src/lib/services/posService.ts` | En `searchProducts` y `getProductsPaginated`: incluir `track_stock` en el select. En `checkout`: para items con `track_stock = false`, omitir validación y descuento de stock. Para items con `track_stock = true`, mantener descuento actual |
+
+#### 4. Transferencias
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/components/inventario/transferencias/TransferenciasService.ts` | Al agregar items: verificar `track_stock`. Si `false`, advertir o bloquear (no tiene sentido transferir sin stock). En `generarMovimientosSalida` y `recibirItems`: omitir productos con `track_stock = false` |
+
+#### 5. Compras (facturas de compra)
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/components/finanzas/facturas-compra/FacturasCompraService.ts` | En `recepcionarInventario`: omitir items con `track_stock = false` (no generar `stock_movements` ni actualizar `stock_levels`) |
+
+### Web Storefront (goadmin-websites)
+
+| Archivo | Cambio |
+|---------|--------|
+| `app/api/orders/route.ts` | En validación B1 (líneas 54-81): excluir productos con `track_stock = false` del chequeo. En reserva de stock (líneas 260-277): saltar productos con `track_stock = false` |
+| `app/api/products/stock/route.ts` | Para productos con `track_stock = false`, retornar `available: null` como indicador de "siempre disponible" |
+| `app/categorias/[slug]/CategoryPageClient.tsx` | Si `track_stock = false` o `available === null`, mostrar badge "Siempre disponible" y siempre permitir compra |
+| `app/components/site/ProductGrid.tsx` o `ProductsList.tsx` | Mostrar "Disponible" en lugar de cantidad para productos sin stock tracking |
+
+---
+
+## UX sugerida
+
+### Checkbox en formulario de producto
+
+```
+[ ] No registrar stock
+    Para productos de difícil control de inventario.
+    Se podrán vender sin validar stock disponible.
+```
+
+- Ubicado en sección "Información básica", junto a campos como SKU y barcode
+- **Disponible tanto en creación como en edición** de producto
+- Al marcarlo, la sección "Inventario inicial por sucursal" se oculta con animación
+- Al desmarcarlo, la sección "Inventario inicial por sucursal" aparece
+- **En edición**, si se desmarca después de haber estado marcado, mostrar advertencia: "Al desactivar el control de stock, los niveles actuales se ignorarán"
+- **En edición**, si se marca después de haber estado desmarcado, mostrar advertencia: "Al activar el control de stock, deberás registrar el stock inicial por sucursal"
+
+### Indicador en listados
+
+- En listado de productos: icono pequeño (ej: ∞) junto al nombre para productos sin stock tracking
+- En POS: badge "Sin stock" o icono ∞ en la tarjeta del producto
+- En tienda web: badge "Siempre disponible" en verde
+
+### Variantes
+
+- Cada variante tiene su propio `track_stock` independiente
+- Al crear variante desde producto padre, hereda el valor `track_stock` del padre
+- Se puede cambiar individualmente por variante
+
+---
+
+## Orden de implementación recomendado
+
+1. **Migración DB**: `ALTER TABLE products ADD COLUMN track_stock boolean DEFAULT true NOT NULL`
+2. **ERP - Formularios**: Checkbox en nuevo y editar producto
+3. **ERP - Inventario**: Filtrar en `stockService.ts`
+4. **ERP - POS**: Incluir campo, omitir validación/descuento
+5. **ERP - Transferencias**: Advertir/bloquear
+6. **ERP - Compras**: Omitir recepción de inventario
+7. **Web Storefront**: Validación, reserva, UI
+
+---
+
+## Resumen de impacto
+
+| Módulo | Productos track_stock=true | Productos track_stock=false |
+|--------|---------------------------|----------------------------|
+| Formulario producto | Stock por sucursal normal | Sin sección de stock |
+| Inventario/Reportes | Aparece en niveles y stats | Excluido |
+| POS | Valida y descuenta stock | Sin validación, sin descuento |
+| Ventas web | Valida y reserva stock | Sin validación, sin reserva |
+| Compras | Suma stock al recepcionar | No genera movimientos |
+| Transferencias | Movimientos de salida/entrada | Bloqueado o advertido |
+| Tienda web | Badge con cantidad | Badge "Siempre disponible" |

--- a/src/app/api/ai-assistant/pm-planner/route.ts
+++ b/src/app/api/ai-assistant/pm-planner/route.ts
@@ -85,6 +85,21 @@ export async function POST(request: NextRequest) {
     });
   } catch (error: any) {
     console.error('Error PM Planner:', error);
+
+    if (error?.status === 429 || error?.code === 'insufficient_quota') {
+      return NextResponse.json(
+        { error: 'Cuota de OpenAI agotada. Revisa el plan y facturación en platform.openai.com.' },
+        { status: 429 }
+      );
+    }
+
+    if (error?.status === 401 || error?.code === 'invalid_api_key') {
+      return NextResponse.json(
+        { error: 'Clave de API de OpenAI inválida o no configurada.' },
+        { status: 401 }
+      );
+    }
+
     return NextResponse.json(
       { error: error.message || 'Error al generar plan con IA' },
       { status: 500 }

--- a/src/app/api/auth/invite/route.ts
+++ b/src/app/api/auth/invite/route.ts
@@ -68,15 +68,11 @@ export async function POST(request: Request) {
       );
     }
 
-    // Fijar la contraseña temporal que espera el flujo actual de /auth/invite
-    if (inviteData?.user?.id) {
-      const { error: pwError } = await admin.auth.admin.updateUserById(inviteData.user.id, {
-        password: 'temp-password',
-      });
-      if (pwError) {
-        console.error('Error fijando contraseña temporal:', pwError);
-      }
-    }
+    // No fijar contraseña temporal: updateUserById invalida el token de invitación
+    // que Supabase envía por email. El flujo correcto es:
+    // 1. Usuario clickea link del email → /auth/verify?token=...&type=invite
+    // 2. verifyOtp establece sesión automáticamente
+    // 3. Redirect a /auth/invite?invite_code=... donde completa su perfil y contraseña
 
     return NextResponse.json({ success: true, inviteUrl });
   } catch (error: any) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -187,6 +187,7 @@ async function createOrUpdateUserProfile(supabase: any, user: any) {
           first_name: finalFirstName,
           last_name: finalLastName,
           avatar_url: avatarUrl,
+          auth_provider: user.app_metadata?.provider || 'email',
           updated_at: new Date().toISOString()
         })
         .eq('id', user.id);
@@ -208,6 +209,7 @@ async function createOrUpdateUserProfile(supabase: any, user: any) {
           first_name: finalFirstName,
           last_name: finalLastName,
           avatar_url: avatarUrl,
+          auth_provider: user.app_metadata?.provider || 'email',
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
         });

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { resetPassword } from '@/lib/supabase/config';
+import { checkAuthProvider, getProviderLabel } from '@/lib/auth';
 import { useTranslations } from 'next-intl';
 
 export default function ForgotPasswordPage() {
@@ -59,6 +60,17 @@ export default function ForgotPasswordPage() {
     setMessage(null);
 
     try {
+      // Verificar si el usuario está registrado con OAuth
+      const provider = await checkAuthProvider(email);
+      if (provider) {
+        setMessage({
+          type: 'error',
+          text: `Esta cuenta está registrada con ${getProviderLabel(provider)}. No puedes restablecer la contraseña. Por favor, inicia sesión con ${getProviderLabel(provider)}.`
+        });
+        setLoading(false);
+        return;
+      }
+
       const { error } = await resetPassword(email);
       
       if (error) {

--- a/src/app/auth/invite/page.tsx
+++ b/src/app/auth/invite/page.tsx
@@ -98,36 +98,23 @@ function InviteContent() {
         role_name: invitation.role_name || 'Usuario'
       };
       
-      // PASO 2: Intentar login automático con credenciales temporales
+      // PASO 2: Verificar si ya hay sesión activa (viene de verifyOtp tras clic en email)
       setLoadingMessage(t('autoSignIn'));
-      console.log('Intentando login con:', invitation.email, 'temp-password');
+      console.log('Verificando sesión activa...');
       
-      const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
-        email: invitation.email,
-        password: 'temp-password'
-      });
+      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
       
-      console.log('Resultado de login:', { signInData, signInError });
-      
-      
-      if (signInError) {
-        console.log('Error en login automático:', signInError);
-        setError(t('errorAutoSignIn', { message: signInError.message }));
+      if (session && session.user && !sessionError) {
+        console.log('Sesión activa encontrada para usuario:', session.user.email);
+        setInviteData(invitationData);
+        setIsLoggedIn(true);
         setIsLoading(false);
         return;
       }
       
-      if (!signInData.user) {
-        console.log('Login exitoso pero no hay usuario');
-        setError(t('errorUnexpected'));
-        setIsLoading(false);
-        return;
-      }
-      
-      // PASO 3: Login exitoso, configurar datos y mostrar wizard
-      console.log('Login exitoso, usuario:', signInData.user.email);
-      setInviteData(invitationData);
-      setIsLoggedIn(true);
+      // Si no hay sesión, mostrar error con instrucciones
+      console.log('No hay sesión activa. El usuario debe clickear el enlace del email primero.');
+      setError(t('errorAutoSignIn', { message: 'Debes abrir el enlace enviado a tu correo electrónico para acceder. Si ya lo abriste, solicita un reenvío de la invitación.' }));
       setIsLoading(false);
       
     } catch (err) {

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -6,12 +6,14 @@ export const dynamic = 'force-dynamic';
 import { useState, useEffect, Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { 
-  handleEmailLogin, 
-  handleGoogleLogin, 
-  handleMicrosoftLogin, 
+import {
+  handleEmailLogin,
+  handleGoogleLogin,
+  handleMicrosoftLogin,
   selectOrganizationFromPopup,
   proceedWithLogin,
+  checkAuthProvider,
+  getProviderLabel,
   Organization
 } from '@/lib/auth';
 import GeolocationModal from '@/components/auth/GeolocationModal';
@@ -105,10 +107,27 @@ function LoginContent() {
     }
   }, [searchParams, userOrganizations]);
 
+  const [oauthProvider, setOauthProvider] = useState<string | null>(null);
+
+  const onEmailBlur = async () => {
+    if (!email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return;
+    setOauthProvider(null);
+    const provider = await checkAuthProvider(email);
+    if (provider) {
+      setOauthProvider(provider);
+    }
+  };
+
   const onEmailLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     // Resetear estado de email no confirmado
     setEmailNotConfirmed(false);
+
+    // Si el usuario está registrado con OAuth, bloquear login con contraseña
+    if (oauthProvider) {
+      setError(`Esta cuenta está registrada con ${getProviderLabel(oauthProvider)}. Por favor, inicia sesión con ese proveedor.`);
+      return;
+    }
 
     // Guardar o eliminar credenciales segun rememberMe
     if (rememberMe) {
@@ -412,9 +431,18 @@ function LoginContent() {
                   placeholder={t('emailPlaceholder')}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  onBlur={onEmailBlur}
                 />
               </div>
             </div>
+            {oauthProvider && (
+              <div className="flex items-center gap-2 text-xs sm:text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+                <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M8.485 2.495c.671-1.167 2.357-1.167 3.028 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                </svg>
+                <span>Esta cuenta está registrada con <strong>{getProviderLabel(oauthProvider)}</strong>. Usa el botón de {getProviderLabel(oauthProvider)} para iniciar sesión.</span>
+              </div>
+            )}
             <div className="relative">
               <div className="flex items-center border border-blue-300 rounded-md">
                 <span className="pl-2 sm:pl-3 pr-1 sm:pr-2 text-blue-500">

--- a/src/app/auth/verify/route.ts
+++ b/src/app/auth/verify/route.ts
@@ -114,9 +114,16 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      // invite: sesión establecida con contraseña temporal; redirigir a reset-password
-      // para que el usuario defina su contraseña definitiva
+      // invite: verifyOtp establece sesión; redirigir a /auth/invite con el código
+      // de invitación para que el usuario complete su perfil y defina su contraseña
       if (type === 'invite') {
+        const inviteCode = user.user_metadata?.invitation_code;
+        if (inviteCode) {
+          return NextResponse.redirect(
+            new URL(`/auth/invite?invite_code=${inviteCode}`, request.url)
+          );
+        }
+        // Si no hay código de invitación en metadata, redirigir a reset-password
         return NextResponse.redirect(new URL('/auth/reset-password', request.url));
       }
     } catch (error: any) {

--- a/src/components/auth/InvitationWizard.tsx
+++ b/src/components/auth/InvitationWizard.tsx
@@ -154,7 +154,49 @@ export default function InvitationWizard({ inviteData, onComplete }: InvitationW
 
       console.log('✅ Perfil actualizado exitosamente');
 
-    
+      // 4. Crear membresía en la organización
+      console.log('👥 Creando membresía en organización...');
+      const { data: existingMembership } = await supabase
+        .from('organization_members')
+        .select('id')
+        .eq('user_id', authData.user.id)
+        .eq('organization_id', inviteData.organization_id)
+        .single();
+
+      if (!existingMembership) {
+        const { error: membershipError } = await supabase
+          .from('organization_members')
+          .insert({
+            user_id: authData.user.id,
+            organization_id: inviteData.organization_id,
+            role_id: inviteData.role_id,
+            is_active: true,
+            joined_at: new Date().toISOString()
+          });
+
+        if (membershipError) {
+          console.log('Error creando membresía:', membershipError);
+          throw new Error(`Error al crear membresía: ${membershipError.message}`);
+        }
+        console.log('✅ Membresía creada exitosamente');
+      } else {
+        const { error: updateMembershipError } = await supabase
+          .from('organization_members')
+          .update({
+            role_id: inviteData.role_id,
+            is_active: true,
+            joined_at: new Date().toISOString()
+          })
+          .eq('user_id', authData.user.id)
+          .eq('organization_id', inviteData.organization_id);
+
+        if (updateMembershipError) {
+          console.log('Error actualizando membresía:', updateMembershipError);
+          throw new Error(`Error al actualizar membresía: ${updateMembershipError.message}`);
+        }
+        console.log('✅ Membresía actualizada exitosamente');
+      }
+
       // 5. Marcar invitación como utilizada
       console.log('✅ Marcando invitación como utilizada...');
       const { error: invitationError } = await supabase

--- a/src/components/pm/ai/AITaskPlanner.tsx
+++ b/src/components/pm/ai/AITaskPlanner.tsx
@@ -97,6 +97,12 @@ export function AITaskPlanner({ projectId, onTasksCreated }: AITaskPlannerProps)
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
+        if (response.status === 429) {
+          throw new Error('Cuota de OpenAI agotada. Revisa el plan y facturación en platform.openai.com.');
+        }
+        if (response.status === 401) {
+          throw new Error('Clave de API de OpenAI inválida o no configurada. Contacta al administrador.');
+        }
         throw new Error(errorData.error || 'Error generando plan con IA');
       }
 

--- a/src/lib/auth/checkProvider.ts
+++ b/src/lib/auth/checkProvider.ts
@@ -1,0 +1,35 @@
+import { supabase } from '@/lib/supabase/config';
+
+/**
+ * Verifica si un email está registrado con un proveedor OAuth (google, azure, etc.)
+ * Retorna el nombre del proveedor o null si el usuario no existe o usa email/password.
+ */
+export async function checkAuthProvider(email: string): Promise<string | null> {
+  try {
+    const { data, error } = await supabase
+      .rpc('get_auth_provider_by_email', { p_email: email });
+
+    if (error || !data) return null;
+
+    if (data && data !== 'email') {
+      return data;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Retorna un mensaje legible para el proveedor OAuth.
+ */
+export function getProviderLabel(provider: string): string {
+  const labels: Record<string, string> = {
+    google: 'Google',
+    azure: 'Microsoft',
+    github: 'GitHub',
+    facebook: 'Facebook',
+  };
+  return labels[provider] || provider;
+}

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -3,3 +3,4 @@ export * from './emailAuth';
 export * from './googleAuth';
 export * from './microsoftAuth';
 export * from './organizationAuth';
+export * from './checkProvider';


### PR DESCRIPTION
fix(auth): corregir flujo de invitación que invalidaba token y no creaba membresía
 
- Eliminar updateUserById en /api/auth/invite que invalidaba el token de invitación
- Redirigir type=invite a /auth/invite con invite_code en verify route
- Reemplazar login con temp-password por detección de sesión activa en invite page
- Crear/actualizar organization_members en InvitationWizard
- Manejar errores 429 y 401 de OpenAI en AITaskPlanner y pm-planner route
- Documentar feature track_stock en .md