### PR TITLE
feat(PM): mostrar tarea principal en lista, kanban y drawer de subtareas

### DIFF
--- a/src/app/app/pm/tareas/page.tsx
+++ b/src/app/app/pm/tareas/page.tsx
@@ -111,6 +111,12 @@ export default function PMTasksPage() {
     if (sub) setEditTask(sub);
   };
 
+  // Abrir la tarea padre desde una subtarea en el editor completo
+  const openParentTask = async (parentTaskId: string) => {
+    const parent = await pmService.getTaskById(parentTaskId);
+    if (parent) setEditTask(parent);
+  };
+
   const loadTasks = useCallback(async () => {
     setLoading(true);
     try {
@@ -380,6 +386,7 @@ export default function PMTasksPage() {
         editTask={editTask}
         onTaskCreated={loadTasks}
         onOpenSubtask={openSubtask}
+        onOpenParent={openParentTask}
       />
     </div>
   );

--- a/src/components/pm/TaskCreationPanel.tsx
+++ b/src/components/pm/TaskCreationPanel.tsx
@@ -20,6 +20,7 @@ import {
   Clock,
   Link2,
   Maximize2,
+  GitBranch,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -78,6 +79,7 @@ interface TaskCreationPanelProps {
   editTask?: PMTask | null;
   onTaskCreated: () => void;
   onOpenSubtask?: (subtaskId: string) => void;
+  onOpenParent?: (parentTaskId: string) => void;
 }
 
 const INITIAL_FORM = {
@@ -105,7 +107,7 @@ function getFileIcon(type: string) {
   return <File className="h-4 w-4 text-gray-500" />;
 }
 
-export default function TaskCreationPanel({ isOpen, onClose, projects, existingTasks = [], users = [], editTask, onTaskCreated, onOpenSubtask }: TaskCreationPanelProps) {
+export default function TaskCreationPanel({ isOpen, onClose, projects, existingTasks = [], users = [], editTask, onTaskCreated, onOpenSubtask, onOpenParent }: TaskCreationPanelProps) {
   const { toast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isMobile, setIsMobile] = useState(false);
@@ -545,6 +547,28 @@ export default function TaskCreationPanel({ isOpen, onClose, projects, existingT
             autoFocus
           />
         </div>
+
+        {/* Tarea padre (si es subtarea) */}
+        {isEdit && editTask?.parent_task && (
+          <div className="flex items-center gap-2 bg-indigo-50 dark:bg-indigo-900/20 rounded-lg px-3 py-2 border border-indigo-100 dark:border-indigo-800">
+            <GitBranch className="h-4 w-4 text-indigo-500 flex-shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="text-[11px] text-indigo-500 dark:text-indigo-400 font-medium">Pertenece a</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300 truncate">{editTask.parent_task.title}</p>
+            </div>
+            {onOpenParent && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => onOpenParent(editTask.parent_task!.id)}
+                className="h-7 gap-1 text-xs border-indigo-200 text-indigo-600 hover:bg-indigo-50 dark:border-indigo-800 dark:text-indigo-400"
+              >
+                <Maximize2 className="h-3.5 w-3.5" />Abrir tarea
+              </Button>
+            )}
+          </div>
+        )}
 
         {/* Descripción */}
         <div className="space-y-1.5">

--- a/src/components/pm/views/KanbanBoard.tsx
+++ b/src/components/pm/views/KanbanBoard.tsx
@@ -11,6 +11,7 @@ import {
   Calendar,
   GripVertical,
   AlertTriangle,
+  GitBranch,
 } from 'lucide-react';
 import { pmService, type PMTask, type TaskTimeEntry, PRIORITY_COLORS, PRIORITY_LABELS, TASK_STATUS_LABELS } from '@/lib/services/pmService';
 import { TaskTimer } from '@/components/pm/TaskTimer';
@@ -139,6 +140,17 @@ export function KanbanBoard({ tasks, onTaskUpdate, onTaskClick, runningTimers }:
                                   <Badge className={`text-[10px] ${PRIORITY_COLORS[task.priority]}`}>
                                     {PRIORITY_LABELS[task.priority]}
                                   </Badge>
+                                  {task.parent_task && (
+                                    <button
+                                      type="button"
+                                      onClick={(e) => { e.stopPropagation(); onTaskClick?.({ ...task, id: task.parent_task!.id, title: task.parent_task!.title }); }}
+                                      title={`Pertenece a: ${task.parent_task.title}`}
+                                      className="inline-flex items-center gap-1 text-[10px] bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300 rounded-full px-2 py-0.5 hover:bg-indigo-200 dark:hover:bg-indigo-900/50 transition-colors"
+                                    >
+                                      <GitBranch className="h-2.5 w-2.5" />
+                                      <span className="truncate max-w-[120px]">{task.parent_task.title}</span>
+                                    </button>
+                                  )}
                                   {isOverdue(task) && (
                                     <Badge className="text-[10px] bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-300">
                                       <AlertTriangle className="h-2.5 w-2.5 mr-0.5" />Vencida

--- a/src/components/pm/views/TaskListView.tsx
+++ b/src/components/pm/views/TaskListView.tsx
@@ -23,6 +23,7 @@ import {
   Trash2,
   CheckCircle2,
   Circle,
+  GitBranch,
 } from 'lucide-react';
 import { type PMTask, type TaskTimeEntry, PRIORITY_COLORS, PRIORITY_LABELS, TASK_STATUS_COLORS, TASK_STATUS_LABELS, TASK_TYPE_LABELS } from '@/lib/services/pmService';
 import { pmService } from '@/lib/services/pmService';
@@ -284,6 +285,17 @@ export function TaskListView({ tasks, onTaskClick, onTaskUpdate, users = [], pro
                       <Badge className="text-[10px] bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300">
                         <Bot className="h-2.5 w-2.5 mr-0.5" />Agente
                       </Badge>
+                    )}
+                    {task.parent_task && (
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); onTaskClick?.({ ...task, id: task.parent_task!.id, title: task.parent_task!.title }); }}
+                        title={`Pertenece a: ${task.parent_task.title}`}
+                        className="inline-flex items-center gap-1 text-[10px] bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300 rounded-full px-2 py-0.5 hover:bg-indigo-200 dark:hover:bg-indigo-900/50 transition-colors"
+                      >
+                        <GitBranch className="h-2.5 w-2.5" />
+                        <span className="truncate max-w-[150px]">{task.parent_task.title}</span>
+                      </button>
                     )}
                     {overdue && (
                       <Badge className="text-[10px] bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-300">

--- a/src/lib/services/pmService.ts
+++ b/src/lib/services/pmService.ts
@@ -111,6 +111,7 @@ export interface PMTask {
   goals?: { id: string; title: string } | null;
   profiles?: { first_name: string; last_name: string; email: string } | null;
   subtasks?: PMTask[];
+  parent_task?: { id: string; title: string; status: string } | null;
 }
 
 export interface TaskTimeEntry {
@@ -419,7 +420,7 @@ export const pmService = {
     // vía el dropdown si el usuario lo selecciona.
     let query = supabase
       .from('tasks')
-      .select('*, projects(id, name), milestones(id, title), goals(id, title)')
+      .select('*, projects(id, name), milestones(id, title), goals(id, title), parent_task:tasks!parent_task_id(id, title, status)')
       .eq('organization_id', orgId)
       .order('created_at', { ascending: false });
 
@@ -629,7 +630,7 @@ export const pmService = {
   },
 
   async getTaskById(taskId: string): Promise<PMTask | null> {
-    const { data, error } = await supabase.from('tasks').select('*').eq('id', taskId).single();
+    const { data, error } = await supabase.from('tasks').select('*, parent_task:tasks!parent_task_id(id, title, status)').eq('id', taskId).single();
     if (error) { console.error('Error getTaskById:', error.message); return null; }
     return data;
   },


### PR DESCRIPTION
- Agregado join parent_task en getTasks y getTaskById de pmService
- Badge 'Pertenece a' clickeable en TaskListView y KanbanBoard
- Seccion 'Pertenece a' con boton 'Abrir tarea' en TaskCreationPanel
- Funcion openParentTask en pagina PM para navegar a la tarea principal