### PR TITLE
Main

### DIFF
--- a/src/components/inventario/productos/editar/FormularioEdicionProducto.tsx
+++ b/src/components/inventario/productos/editar/FormularioEdicionProducto.tsx
@@ -265,7 +265,7 @@ export default function FormularioEdicionProducto({ productoUuid }: FormularioEd
           price: priceData?.price || 0,
           compare_price: priceData?.compare_price || 0,
           tax_id: taxData?.tax_id || '',
-          track_stock: true,
+          track_stock: producto.track_stock !== false,
           status: producto.status || 'active',
           stock_inicial: stockInicial,
           images,
@@ -339,6 +339,7 @@ export default function FormularioEdicionProducto({ productoUuid }: FormularioEd
         unit_code: data.unit_code,
         status: data.status,
         station: data.station ?? null,
+        track_stock: data.track_stock,
         updated_at: new Date().toISOString(),
       };
 

--- a/src/components/inventario/productos/id/tabs/DetallesTab.tsx
+++ b/src/components/inventario/productos/id/tabs/DetallesTab.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'next-themes';
 import { useRouter } from 'next/navigation';
 import { useOrganization } from '@/lib/hooks/useOrganization';
 import { supabase } from '@/lib/supabase/config';
-import { CalendarIcon, Save, Loader2 } from 'lucide-react';
+import { CalendarIcon, Save, Loader2, PackageCheck } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
 
@@ -55,6 +55,7 @@ const DetallesTab: React.FC<DetallesTabProps> = ({ producto }) => {
     unit_code: producto.unit_code || '',
     supplier_id: preferredSupplier?.supplier_id?.toString() || '',
     station: producto.station || null,
+    track_stock: producto.track_stock !== false,
   });
   
   // Cargar datos de categorías, unidades y proveedores al montar el componente
@@ -113,7 +114,10 @@ const DetallesTab: React.FC<DetallesTabProps> = ({ producto }) => {
     setFormData({ ...formData, [name]: processedValue });
   };
   
-  // No longer needed - track_stock has been removed
+  // Manejar cambio en el switch de track_stock
+  const handleTrackStockChange = (checked: boolean) => {
+    setFormData({ ...formData, track_stock: checked });
+  };
   
   // Guardar cambios en el producto
   const handleSaveChanges = async () => {
@@ -130,6 +134,7 @@ const DetallesTab: React.FC<DetallesTabProps> = ({ producto }) => {
           category_id: formData.category_id || null,
           unit_code: formData.unit_code || null,
           station: formData.station || null,
+          track_stock: formData.track_stock,
           updated_at: new Date().toISOString(),
         })
         .eq('id', producto.id)
@@ -303,7 +308,24 @@ const DetallesTab: React.FC<DetallesTabProps> = ({ producto }) => {
           </Select>
         </div>
         
-        {/* Stock tracking removed as it's always on now */}
+        {/* Switch de rastreo de inventario */}
+        <div className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800">
+          <div className="flex items-center gap-3">
+            <PackageCheck className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+            <div>
+              <Label className="text-sm font-medium text-gray-900 dark:text-white">
+                Rastrear inventario
+              </Label>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Si se desactiva, las ventas no descontarán stock de este producto
+              </p>
+            </div>
+          </div>
+          <Switch
+            checked={formData.track_stock}
+            onCheckedChange={handleTrackStockChange}
+          />
+        </div>
       </div>
       
       {/* Metadatos y botón guardar */}

--- a/src/components/inventario/productos/id/tabs/StockTab.tsx
+++ b/src/components/inventario/productos/id/tabs/StockTab.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'next-themes';
 import { useRouter } from 'next/navigation';
 import { useOrganization } from '@/lib/hooks/useOrganization';
 import { supabase } from '@/lib/supabase/config';
-import { Plus, ArrowUp, ArrowDown, History, Loader2 } from 'lucide-react';
+import { Plus, ArrowUp, ArrowDown, History, Loader2, PackageCheck } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/use-toast';
@@ -164,6 +164,22 @@ const StockTab: React.FC<StockTabProps> = ({ producto }) => {
     router.push(`/app/inventario/kardex?producto=${producto.id}`);
   };
   
+  if (producto.track_stock === false) {
+    return (
+      <div className="space-y-6">
+        <div className="text-center py-12 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+          <PackageCheck className="h-12 w-12 mx-auto text-gray-400 mb-4" />
+          <p className="text-gray-500 dark:text-gray-400 font-medium mb-2">
+            Este producto no rastrea inventario
+          </p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">
+            Las ventas de este producto no afectan el stock. Activa el rastreo en la pestaña &quot;Detalles&quot; para gestionar inventario.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
         <>

--- a/src/components/inventario/productos/nuevo/Inventario.tsx
+++ b/src/components/inventario/productos/nuevo/Inventario.tsx
@@ -6,7 +6,8 @@ import { useOrganization } from '@/lib/hooks/useOrganization'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { Warehouse, Plus, Trash2, Loader2 } from 'lucide-react'
+import { Switch } from '@/components/ui/switch'
+import { Warehouse, Plus, Trash2, Loader2, PackageCheck } from 'lucide-react'
 
 interface InventarioProps {
   formData: any
@@ -91,13 +92,32 @@ export default function Inventario({ formData, updateFormData, hasVariants = fal
         <Button
           type="button"
           onClick={addStockEntry}
-          disabled={isLoadingBranches || branches.length === 0}
+          disabled={isLoadingBranches || branches.length === 0 || formData.track_stock === false}
           className="bg-blue-600 hover:bg-blue-700 text-white"
           size="sm"
         >
           <Plus className="h-4 w-4 mr-2" />
           Agregar Sucursal
         </Button>
+      </div>
+
+      {/* Switch de seguimiento de stock */}
+      <div className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800">
+        <div className="flex items-center gap-3">
+          <PackageCheck className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+          <div>
+            <Label className="text-sm font-medium text-gray-900 dark:text-white cursor-pointer">
+              Rastrear inventario
+            </Label>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Si se desactiva, las ventas no descontarán stock de este producto
+            </p>
+          </div>
+        </div>
+        <Switch
+          checked={formData.track_stock !== false}
+          onCheckedChange={(checked) => updateFormData('track_stock', checked)}
+        />
       </div>
 
       {/* Mensaje cuando hay variantes */}

--- a/src/components/inventario/productos/nuevo/NuevoProductoForm.tsx
+++ b/src/components/inventario/productos/nuevo/NuevoProductoForm.tsx
@@ -188,7 +188,8 @@ export default function NuevoProductoForm({ onSuccess, onCancel, embedded = fals
           unit_code: formData.unit_code,
           status: 'active',
           is_parent: formData.has_variants,
-          station: formData.station
+          station: formData.station,
+          track_stock: formData.track_stock !== false
         })
         .select('id, uuid')
         .single()

--- a/src/components/pm/TaskCreationPanel.tsx
+++ b/src/components/pm/TaskCreationPanel.tsx
@@ -142,7 +142,7 @@ export default function TaskCreationPanel({ isOpen, onClose, projects, existingT
   const [goals, setGoals] = useState<Array<{ id: string; title: string }>>([]);
   const [customers, setCustomers] = useState<Array<{ id: string; name: string }>>([]);
   const [spaces, setSpaces] = useState<Array<{ id: string; label: string; type_name: string }>>([]);
-  const [sales, setSales] = useState<Array<{ id: string; total: number; sale_date: string; customer_name: string }>>([]);
+  const [sales, setSales] = useState<Array<{ id: string; total: number; sale_date: string; customer_name: string; source: string }>>([]);
   const [reservations, setReservations] = useState<Array<{ id: string; checkin: string; checkout: string; customer_name: string }>>([]);
   const [pmsActive, setPmsActive] = useState(false);
 
@@ -158,19 +158,40 @@ export default function TaskCreationPanel({ isOpen, onClose, projects, existingT
         .then(({ data }) => {
           setCustomers((data || []).map(c => ({ id: c.id, name: `${c.first_name} ${c.last_name}` })));
         });
-      // Cargar ventas recientes con nombre del cliente
+      // Cargar ventas POS recientes con nombre del cliente
       supabase.from('sales')
-        .select('id, total, sale_date, status, customers(first_name, last_name)')
+        .select('id, total, sale_date, status, table_session_id, customers(first_name, last_name)')
         .eq('organization_id', orgId)
         .order('sale_date', { ascending: false })
         .limit(200)
         .then(({ data }) => {
-          setSales((data || []).map(s => ({
+          const posSales = (data || []).map(s => ({
             id: s.id,
             total: Number(s.total) || 0,
             sale_date: s.sale_date,
             customer_name: s.customers ? `${s.customers.first_name} ${s.customers.last_name}` : 'Sin cliente',
-          })));
+            source: s.table_session_id ? 'Mesa' : 'POS',
+          }));
+          // Cargar ventas Web (web_orders)
+          supabase.from('web_orders')
+            .select('id, total_amount, order_date, customer_name, status')
+            .eq('organization_id', orgId)
+            .order('order_date', { ascending: false })
+            .limit(200)
+            .then(({ data: webData }) => {
+              const webSales = (webData || []).map(w => ({
+                id: w.id,
+                total: Number(w.total_amount) || 0,
+                sale_date: w.order_date,
+                customer_name: w.customer_name || 'Sin cliente',
+                source: 'Web',
+              }));
+              // Combinar y ordenar por fecha descendente
+              const combined = [...posSales, ...webSales].sort((a, b) =>
+                new Date(b.sale_date).getTime() - new Date(a.sale_date).getTime()
+              );
+              setSales(combined);
+            });
         });
       // Verificar si el módulo PMS está activo
       supabase.from('organization_modules')
@@ -777,7 +798,7 @@ export default function TaskCreationPanel({ isOpen, onClose, projects, existingT
                   options={sales.map(s => ({
                     value: s.id,
                     label: `${s.customer_name} — $${s.total.toLocaleString('es-ES', { minimumFractionDigits: 0 })}`,
-                    sublabel: new Date(s.sale_date).toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' }),
+                    sublabel: `${s.source} · ${new Date(s.sale_date).toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' })}`,
                   }))}
                   value={form.related_to_id || 'none'}
                   onValueChange={(v) => setForm(f => ({ ...f, related_to_id: v === 'none' ? '' : v }))}

--- a/src/components/pos/mesas/id/pedidosService.ts
+++ b/src/components/pos/mesas/id/pedidosService.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabase/config';
 import { getOrganizationId, getCurrentBranchId } from '@/lib/hooks/useOrganization';
 import { POSService } from '@/lib/services/posService';
+import { stockMovementService } from '@/lib/services/stockMovementService';
 import {
   calculateItemTaxes,
   type OrganizationTax as TaxUtilOrganizationTax,
@@ -1045,6 +1046,34 @@ export class PedidosService {
       // aquí manualmente generaba asientos duplicados (source='sale' vs 'sales' del
       // trigger) y errores de FK por usar códigos de cuenta hardcodeados que no
       // existen para todas las organizaciones.
+
+      // 7. Descontar stock de los items vendidos
+      try {
+        const { data: saleItemsForStock } = await supabase
+          .from('sale_items')
+          .select('product_id, quantity, unit_price')
+          .eq('sale_id', saleId);
+
+        if (saleItemsForStock && saleItemsForStock.length > 0) {
+          const stockResult = await stockMovementService.decrementOnSale(
+            saleData.organization_id,
+            saleData.branch_id,
+            saleId,
+            saleItemsForStock.map((item: any) => ({
+              product_id: item.product_id,
+              quantity: Number(item.quantity),
+              unit_price: Number(item.unit_price),
+            })),
+            'mesa_sale'
+          );
+          if (stockResult.errors.length > 0) {
+            console.warn('⚠️ Algunos items no descontaron stock:', stockResult.errors);
+          }
+          console.log(`📦 Stock descontado (mesa): ${saleItemsForStock.length - stockResult.skipped} items procesados`);
+        }
+      } catch (stockError) {
+        console.warn('⚠️ Error descontando stock (no bloquea la venta):', stockError);
+      }
 
       return {
         id: saleData.id,

--- a/src/lib/services/checkoutService.ts
+++ b/src/lib/services/checkoutService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase/config';
+import { getOrganizationId, getCurrentBranchId } from '@/lib/hooks/useOrganization';
 
 export interface CheckoutReservation {
   id: string;
@@ -305,22 +306,145 @@ class CheckoutService {
       if (folioError) throw folioError;
     }
 
+    // Crear venta desde el folio si hay items
+    if (folio) {
+      try {
+        await this.createSaleFromFolio(folio.id, reservationId, userId, generateInvoice);
+      } catch (saleError) {
+        console.warn('⚠️ Error creando venta desde folio (no bloquea checkout):', saleError);
+      }
+    }
+
     // Crear tarea de limpieza para las habitaciones
     await this.createHousekeepingTasks(reservationId);
 
     // Actualizar estado de espacios a 'cleaning' después de crear tareas de limpieza
     await this.updateSpaceStatus(reservationId, 'cleaning');
 
-    // TODO: Implementar generación de factura/recibo si es necesario
-    if (generateInvoice) {
-      // Lógica para generar factura
-      console.log('Generar factura para reserva:', reservationId);
+    // La factura se genera en createSaleFromFolio si generateInvoice es true
+  }
+
+  /**
+   * Crear venta + sale_items desde los folio_items
+   * El stock ya fue descontado al agregar consumos, aqui no se descuenta de nuevo.
+   */
+  private async createSaleFromFolio(
+    folioId: string,
+    reservationId: string,
+    userId?: string,
+    generateInvoice: boolean = false
+  ): Promise<void> {
+    // Obtener datos de la reserva y folio
+    const { data: reservation } = await supabase
+      .from('reservations')
+      .select('organization_id, branch_id, customer_id, total_estimated')
+      .eq('id', reservationId)
+      .single();
+
+    if (!reservation) return;
+
+    const { data: folioItems } = await supabase
+      .from('folio_items')
+      .select('id, description, amount, product_id, quantity, unit_price, source')
+      .eq('folio_id', folioId)
+      .order('created_at', { ascending: true });
+
+    if (!folioItems || folioItems.length === 0) return;
+
+    const subtotal = folioItems.reduce((sum, item) => sum + Number(item.amount), 0);
+    const branchId = reservation.branch_id || getCurrentBranchId();
+
+    // Crear la venta
+    const { data: sale, error: saleError } = await supabase
+      .from('sales')
+      .insert({
+        organization_id: reservation.organization_id,
+        branch_id: branchId,
+        customer_id: reservation.customer_id || null,
+        user_id: userId || null,
+        subtotal,
+        tax_total: 0,
+        discount_total: 0,
+        total: subtotal,
+        balance: 0,
+        status: 'paid',
+        payment_status: 'paid',
+        notes: `Checkout reserva ${reservationId.slice(0, 8)}`,
+        sale_date: new Date().toISOString(),
+      })
+      .select('id')
+      .single();
+
+    if (saleError) {
+      console.error('Error creando sale desde folio:', saleError);
+      return;
     }
 
-    if (generateReceipt) {
-      // Lógica para generar recibo
-      console.log('Generar recibo para reserva:', reservationId);
+    // Crear sale_items desde folio_items
+    const saleItems = folioItems.map((item: any) => ({
+      sale_id: sale.id,
+      product_id: item.product_id || null,
+      quantity: Number(item.quantity) || 1,
+      unit_price: Number(item.unit_price) || Number(item.amount),
+      total: Number(item.amount),
+      tax_amount: 0,
+      discount_amount: 0,
+      notes: item.description,
+    }));
+
+    const { error: itemsError } = await supabase
+      .from('sale_items')
+      .insert(saleItems);
+
+    if (itemsError) {
+      console.error('Error creando sale_items desde folio:', itemsError);
     }
+
+    // Vincular folio con la venta
+    await supabase
+      .from('folios')
+      .update({ sale_id: sale.id })
+      .eq('id', folioId);
+
+    // Generar factura si se solicitó
+    if (generateInvoice) {
+      try {
+        const { data: invoiceCount } = await supabase
+          .from('invoice_sales')
+          .select('id')
+          .eq('organization_id', reservation.organization_id);
+
+        const invoiceNumber = `FAC-${(invoiceCount?.length || 0) + 1}-${new Date().getFullYear()}`;
+
+        await supabase
+          .from('invoice_sales')
+          .insert({
+            organization_id: reservation.organization_id,
+            branch_id: branchId,
+            customer_id: reservation.customer_id || null,
+            sale_id: sale.id,
+            number: invoiceNumber,
+            issue_date: new Date().toISOString(),
+            due_date: new Date().toISOString(),
+            currency: 'COP',
+            subtotal,
+            tax_total: 0,
+            total: subtotal,
+            balance: 0,
+            status: 'paid',
+            payment_method: 'folio',
+            document_type: 'invoice',
+            created_by: userId || null,
+            notes: `Factura desde checkout - Reserva ${reservationId.slice(0, 8)}`,
+          });
+
+        console.log(`📄 Factura generada para reserva ${reservationId.slice(0, 8)}`);
+      } catch (invoiceError) {
+        console.warn('⚠️ Error generando factura (no bloquea checkout):', invoiceError);
+      }
+    }
+
+    console.log(`🧾 Venta creada desde folio: ${sale.id} para reserva ${reservationId.slice(0, 8)}`);
   }
 
   /**

--- a/src/lib/services/foliosService.ts
+++ b/src/lib/services/foliosService.ts
@@ -1,4 +1,6 @@
 import { supabase } from '@/lib/supabase/config';
+import { stockMovementService } from './stockMovementService';
+import { getOrganizationId, getCurrentBranchId } from '@/lib/hooks/useOrganization';
 
 export interface Folio {
   id: string;
@@ -30,6 +32,9 @@ export interface FolioItem {
   description: string;
   amount: number;
   tax_code?: string;
+  product_id?: number | null;
+  quantity?: number | null;
+  unit_price?: number | null;
   created_by?: string;
   created_at: string;
   updated_at: string;
@@ -58,6 +63,9 @@ export interface CreateFolioItemData {
   description: string;
   amount: number;
   tax_code?: string;
+  product_id?: number | null;
+  quantity?: number | null;
+  unit_price?: number | null;
   created_by?: string;
 }
 
@@ -227,6 +235,27 @@ class FoliosService {
 
       console.log('Item creado exitosamente:', item.id);
 
+      // Descontar stock si el item tiene product_id
+      if (data.product_id && data.quantity && data.quantity > 0) {
+        try {
+          const orgId = getOrganizationId();
+          const branchId = getCurrentBranchId();
+          const stockResult = await stockMovementService.decrementOnSale(
+            orgId,
+            branchId,
+            data.folio_id,
+            [{ product_id: data.product_id, quantity: Number(data.quantity), unit_price: Number(data.unit_price || 0) }],
+            'folio_item',
+            data.created_by
+          );
+          if (stockResult.errors.length > 0) {
+            console.warn('⚠️ Folio item no descontó stock:', stockResult.errors);
+          }
+        } catch (stockError) {
+          console.warn('⚠️ Error descontando stock (no bloquea el item):', stockError);
+        }
+      }
+
       // Actualizar balance del folio
       await this.updateFolioBalance(data.folio_id);
 
@@ -246,12 +275,37 @@ class FoliosService {
    */
   async deleteFolioItem(itemId: string, folioId: string): Promise<void> {
     try {
+      // Obtener el item antes de eliminarlo para saber si hay que revertir stock
+      const { data: item } = await supabase
+        .from('folio_items')
+        .select('product_id, quantity, unit_price')
+        .eq('id', itemId)
+        .maybeSingle();
+
       const { error } = await supabase
         .from('folio_items')
         .delete()
         .eq('id', itemId);
 
       if (error) throw error;
+
+      // Revertir stock si el item tenía product_id
+      if (item?.product_id && item?.quantity && Number(item.quantity) > 0) {
+        try {
+          const orgId = getOrganizationId();
+          const branchId = getCurrentBranchId();
+          await stockMovementService.incrementOnPurchase(
+            orgId,
+            branchId,
+            folioId,
+            [{ product_id: item.product_id, quantity: Number(item.quantity), unit_price: Number(item.unit_price || 0) }],
+            'folio_item_reversal'
+          );
+          console.log(`📦 Stock revertido (folio item eliminado): producto ${item.product_id}`);
+        } catch (stockError) {
+          console.warn('⚠️ Error revirtiendo stock (no bloquea eliminación):', stockError);
+        }
+      }
 
       // Actualizar balance del folio
       await this.updateFolioBalance(folioId);

--- a/src/lib/services/posService.ts
+++ b/src/lib/services/posService.ts
@@ -3,6 +3,7 @@ import { getOrganizationId, getCurrentBranchId, getCurrentUserId } from '@/lib/h
 import { generateInvoiceNumber as generateInvoiceNumberUtil } from '@/lib/utils/invoiceUtils';
 import { calculateCartTaxesComplete, getTaxIncludedSetting, formatTaxCalculationForLog, type TaxCalculationItem } from '@/lib/utils/taxCalculations';
 import { CreditNoteNumberService } from '@/lib/services/creditNoteNumberService';
+import { stockMovementService } from '@/lib/services/stockMovementService';
 import {
   Product,
   Customer,
@@ -898,6 +899,23 @@ export class POSService {
       }
       
       console.log(`🛍️ ${saleItems.length} items de venta creados exitosamente`);
+
+      // Descontar stock por cada item vendido
+      try {
+        const stockResult = await stockMovementService.decrementOnSale(
+          this.organizationId,
+          getCurrentBranchId(),
+          sale.id,
+          cart.items.map(item => ({ product_id: item.product_id, quantity: item.quantity, unit_price: item.unit_price })),
+          'sale'
+        );
+        if (stockResult.errors.length > 0) {
+          console.warn('⚠️ Algunos items no descontaron stock:', stockResult.errors);
+        }
+        console.log(`📦 Stock descontado: ${cart.items.length - stockResult.skipped} items procesados`);
+      } catch (stockError) {
+        console.warn('⚠️ Error descontando stock (no bloquea la venta):', stockError);
+      }
       
       // PASO 5: La cuenta por cobrar se crea automáticamente por el trigger tr_create_account_receivable
       // al insertar la factura con status != 'draft'. Obtenemos la cuenta creada usando RPC:
@@ -1053,6 +1071,23 @@ export class POSService {
         .insert(saleItems);
 
       if (itemsError) throw itemsError;
+
+      // Descontar stock por cada item vendido
+      try {
+        const stockResult = await stockMovementService.decrementOnSale(
+          cart.organization_id,
+          getCurrentBranchId(),
+          saleData.id,
+          cart.items.map(item => ({ product_id: item.product_id, quantity: item.quantity, unit_price: item.unit_price })),
+          'sale'
+        );
+        if (stockResult.errors.length > 0) {
+          console.warn('⚠️ Algunos items no descontaron stock:', stockResult.errors);
+        }
+        console.log(`📦 Stock descontado: ${cart.items.length - stockResult.skipped} items procesados`);
+      } catch (stockError) {
+        console.warn('⚠️ Error descontando stock (no bloquea la venta):', stockError);
+      }
 
       // Crear la factura (invoice_sales)
       const invoiceNumber = await this.generateInvoiceNumber();

--- a/src/lib/services/purchaseOrderService.ts
+++ b/src/lib/services/purchaseOrderService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase/config';
+import { stockMovementService } from '@/lib/services/stockMovementService';
 
 // Tipos para Órdenes de Compra
 export interface PurchaseOrder {
@@ -433,10 +434,10 @@ class PurchaseOrderService {
     itemsReceived: { itemId: number; quantity: number }[]
   ): Promise<{ success: boolean; error: Error | null }> {
     try {
-      // Obtener el ID numérico de la orden
+      // Obtener el ID numérico de la orden y branch_id
       const { data: order } = await supabase
         .from('purchase_orders')
-        .select('id')
+        .select('id, branch_id')
         .eq('uuid', orderUuid)
         .eq('organization_id', organizationId)
         .single();
@@ -446,6 +447,17 @@ class PurchaseOrderService {
       }
 
       const orderId = order.id;
+      const branchId = order.branch_id;
+
+      // Obtener received_quantity actual para calcular delta
+      const itemIds = itemsReceived.map(i => i.itemId);
+      const { data: currentItems } = await supabase
+        .from('purchase_order_items')
+        .select('id, product_id, unit_cost, received_quantity')
+        .in('id', itemIds)
+        .eq('purchase_order_id', orderId);
+
+      const currentMap = new Map((currentItems || []).map(i => [i.id, i]));
 
       // Actualizar cantidad recibida de cada item
       for (const item of itemsReceived) {
@@ -459,6 +471,41 @@ class PurchaseOrderService {
           .eq('purchase_order_id', orderId);
 
         if (error) throw error;
+      }
+
+      // Sumar stock por el delta recibido (nuevo - anterior)
+      try {
+        const stockItems = itemsReceived
+          .map(item => {
+            const current = currentMap.get(item.itemId);
+            if (!current || !current.product_id) return null;
+            const prevQty = Number(current.received_quantity) || 0;
+            const newQty = Number(item.quantity) || 0;
+            const delta = newQty - prevQty;
+            if (delta <= 0) return null;
+            return {
+              product_id: current.product_id,
+              quantity: delta,
+              unit_price: Number(current.unit_cost) || 0,
+            };
+          })
+          .filter((item): item is { product_id: number; quantity: number; unit_price: number } => item !== null);
+
+        if (stockItems.length > 0) {
+          const stockResult = await stockMovementService.incrementOnPurchase(
+            organizationId,
+            branchId,
+            orderId,
+            stockItems,
+            'purchase_order'
+          );
+          if (stockResult.errors.length > 0) {
+            console.warn('⚠️ Algunos items no sumaron stock:', stockResult.errors);
+          }
+          console.log(`📦 Stock incrementado (OC ${orderId}): ${stockItems.length - stockResult.skipped} items`);
+        }
+      } catch (stockError) {
+        console.warn('⚠️ Error sumando stock (no bloquea recepción):', stockError);
       }
 
       // Verificar si es recepción total o parcial

--- a/src/lib/services/spaceConsumptionService.ts
+++ b/src/lib/services/spaceConsumptionService.ts
@@ -1,5 +1,7 @@
 import { supabase } from '@/lib/supabase/config';
 import FoliosService from './foliosService';
+import { stockMovementService } from './stockMovementService';
+import { getOrganizationId, getCurrentBranchId } from '@/lib/hooks/useOrganization';
 
 export interface SpaceConsumption {
   id: string;
@@ -190,8 +192,31 @@ class SpaceConsumptionService {
           source: 'room_service',
           description: `${consumption.quantity}x ${consumption.product_name}${consumption.notes ? ` - ${consumption.notes}` : ''}`,
           amount,
+          product_id: consumption.product_id,
+          quantity: consumption.quantity,
+          unit_price: consumption.unit_price,
           created_by: userId,
         });
+      }
+
+      // Descontar stock por cada consumo con product_id
+      try {
+        const orgId = getOrganizationId();
+        const branchId = getCurrentBranchId();
+        const stockResult = await stockMovementService.decrementOnSale(
+          orgId,
+          branchId,
+          folioId,
+          consumptions.map(c => ({ product_id: c.product_id, quantity: c.quantity, unit_price: c.unit_price })),
+          'room_consumption',
+          userId
+        );
+        if (stockResult.errors.length > 0) {
+          console.warn('⚠️ Algunos consumos no descontaron stock:', stockResult.errors);
+        }
+        console.log(`📦 Stock descontado (consumo habitación): ${consumptions.length - stockResult.skipped} items`);
+      } catch (stockError) {
+        console.warn('⚠️ Error descontando stock (no bloquea el consumo):', stockError);
       }
     } catch (error) {
       console.error('Error agregando consumos:', error);

--- a/src/lib/services/stockMovementService.ts
+++ b/src/lib/services/stockMovementService.ts
@@ -1,0 +1,327 @@
+import { supabase } from '@/lib/supabase/config';
+
+export interface SaleItemForStock {
+  product_id: number | null;
+  quantity: number;
+  unit_price?: number;
+}
+
+export interface StockDecrementResult {
+  success: boolean;
+  skipped: number;
+  errors: string[];
+}
+
+/**
+ * Servicio reutilizable para descontar stock al realizar ventas.
+ * Maneja la lógica de llamar a la RPC decrement_stock_on_sale por cada item.
+ */
+export const stockMovementService = {
+  /**
+   * Descuenta stock por cada item de una venta.
+   * Verifica track_stock en BD (via RPC), omite items sin product_id.
+   *
+   * @param organizationId - ID de la organización
+   * @param branchId - ID de la sucursal
+   * @param saleId - ID de la venta (para source_id)
+   * @param items - Items de la venta
+   * @param source - Origen del movimiento ('sale', 'web_sale', 'mesa_sale', 'invoice_sale')
+   * @param updatedBy - UUID del usuario (opcional)
+   */
+  async decrementOnSale(
+    organizationId: number,
+    branchId: number,
+    saleId: string | number,
+    items: SaleItemForStock[],
+    source: string = 'sale',
+    updatedBy?: string
+  ): Promise<StockDecrementResult> {
+    const errors: string[] = [];
+    let skipped = 0;
+
+    for (const item of items) {
+      // Saltar items sin product_id (ej: propinas, cargos personalizados)
+      if (!item.product_id) {
+        skipped++;
+        continue;
+      }
+
+      const qty = Number(item.quantity) || 0;
+      if (qty <= 0) {
+        skipped++;
+        continue;
+      }
+
+      const { error: rpcError } = await supabase.rpc('decrement_stock_on_sale', {
+        p_organization_id: organizationId,
+        p_branch_id: branchId,
+        p_product_id: item.product_id,
+        p_qty: qty,
+        p_source: source,
+        p_source_id: String(saleId),
+        p_unit_cost: item.unit_price ?? null,
+        p_updated_by: updatedBy ?? null,
+      });
+
+      if (rpcError) {
+        console.warn(
+          `[stockMovementService] Error descontando stock producto ${item.product_id}:`,
+          rpcError.message
+        );
+        errors.push(`Producto ${item.product_id}: ${rpcError.message}`);
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      skipped,
+      errors,
+    };
+  },
+
+  /**
+   * Reserva stock al crear un pedido web.
+   * Incrementa qty_reserved en stock_levels.
+   */
+  async reserveStock(
+    organizationId: number,
+    branchId: number,
+    orderId: string | number,
+    items: SaleItemForStock[],
+    updatedBy?: string
+  ): Promise<StockDecrementResult> {
+    const errors: string[] = [];
+    let skipped = 0;
+
+    for (const item of items) {
+      if (!item.product_id) {
+        skipped++;
+        continue;
+      }
+
+      const qty = Number(item.quantity) || 0;
+      if (qty <= 0) {
+        skipped++;
+        continue;
+      }
+
+      // Verificar track_stock del producto
+      const { data: product } = await supabase
+        .from('products')
+        .select('track_stock')
+        .eq('id', item.product_id)
+        .single();
+
+      if (!product || product.track_stock === false) {
+        skipped++;
+        continue;
+      }
+
+      // Incrementar qty_reserved
+      const { data: existing } = await supabase
+        .from('stock_levels')
+        .select('id, qty_reserved')
+        .eq('product_id', item.product_id)
+        .eq('branch_id', branchId)
+        .is('lot_id', null)
+        .maybeSingle();
+
+      if (existing) {
+        const { error } = await supabase
+          .from('stock_levels')
+          .update({
+            qty_reserved: (Number(existing.qty_reserved) || 0) + qty,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', existing.id);
+
+        if (error) errors.push(`Producto ${item.product_id}: ${error.message}`);
+      } else {
+        const { error } = await supabase
+          .from('stock_levels')
+          .insert({
+            product_id: item.product_id,
+            branch_id: branchId,
+            lot_id: null,
+            qty_on_hand: 0,
+            qty_reserved: qty,
+            avg_cost: 0,
+            min_level: 0,
+          });
+
+        if (error) errors.push(`Producto ${item.product_id}: ${error.message}`);
+      }
+    }
+
+    return { success: errors.length === 0, skipped, errors };
+  },
+
+  /**
+   * Libera la reserva de stock al cancelar un pedido web.
+   */
+  async releaseStockReservation(
+    branchId: number,
+    orderId: string | number,
+    items: SaleItemForStock[]
+  ): Promise<StockDecrementResult> {
+    const errors: string[] = [];
+    let skipped = 0;
+
+    for (const item of items) {
+      if (!item.product_id) {
+        skipped++;
+        continue;
+      }
+
+      const qty = Number(item.quantity) || 0;
+      if (qty <= 0) {
+        skipped++;
+        continue;
+      }
+
+      const { data: existing } = await supabase
+        .from('stock_levels')
+        .select('id, qty_reserved')
+        .eq('product_id', item.product_id)
+        .eq('branch_id', branchId)
+        .is('lot_id', null)
+        .maybeSingle();
+
+      if (existing) {
+        const newReserved = Math.max(0, (Number(existing.qty_reserved) || 0) - qty);
+        const { error } = await supabase
+          .from('stock_levels')
+          .update({
+            qty_reserved: newReserved,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', existing.id);
+
+        if (error) errors.push(`Producto ${item.product_id}: ${error.message}`);
+      }
+    }
+
+    return { success: errors.length === 0, skipped, errors };
+  },
+
+  /**
+   * Incrementa stock al recibir items de una orden de compra.
+   * Suma a qty_on_hand y crea stock_movements con direction='in'.
+   *
+   * @param organizationId - ID de la organización
+   * @param branchId - ID de la sucursal
+   * @param orderId - ID de la orden de compra (para source_id)
+   * @param items - Items recibidos con product_id, quantity (delta) y unit_cost
+   * @param source - Origen ('purchase_order', 'purchase_invoice')
+   * @param updatedBy - UUID del usuario (opcional)
+   */
+  async incrementOnPurchase(
+    organizationId: number,
+    branchId: number,
+    orderId: string | number,
+    items: SaleItemForStock[],
+    source: string = 'purchase_order',
+    updatedBy?: string
+  ): Promise<StockDecrementResult> {
+    const errors: string[] = [];
+    let skipped = 0;
+
+    for (const item of items) {
+      if (!item.product_id) {
+        skipped++;
+        continue;
+      }
+
+      const qty = Number(item.quantity) || 0;
+      if (qty <= 0) {
+        skipped++;
+        continue;
+      }
+
+      // Verificar track_stock del producto
+      const { data: product } = await supabase
+        .from('products')
+        .select('track_stock')
+        .eq('id', item.product_id)
+        .single();
+
+      if (!product || product.track_stock === false) {
+        skipped++;
+        continue;
+      }
+
+      // Buscar stock_level existente
+      const { data: existing } = await supabase
+        .from('stock_levels')
+        .select('id, qty_on_hand, avg_cost')
+        .eq('product_id', item.product_id)
+        .eq('branch_id', branchId)
+        .is('lot_id', null)
+        .maybeSingle();
+
+      const unitCost = Number(item.unit_price) || 0;
+
+      if (existing) {
+        const currentQty = Number(existing.qty_on_hand) || 0;
+        const currentAvgCost = Number(existing.avg_cost) || 0;
+        // Recalcular costo promedio ponderado
+        const newAvgCost = currentQty > 0
+          ? (currentQty * currentAvgCost + qty * unitCost) / (currentQty + qty)
+          : unitCost;
+
+        const { error } = await supabase
+          .from('stock_levels')
+          .update({
+            qty_on_hand: currentQty + qty,
+            avg_cost: newAvgCost,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', existing.id);
+
+        if (error) {
+          errors.push(`Producto ${item.product_id}: ${error.message}`);
+          continue;
+        }
+      } else {
+        const { error } = await supabase
+          .from('stock_levels')
+          .insert({
+            product_id: item.product_id,
+            branch_id: branchId,
+            lot_id: null,
+            qty_on_hand: qty,
+            qty_reserved: 0,
+            avg_cost: unitCost,
+            min_level: 0,
+          });
+
+        if (error) {
+          errors.push(`Producto ${item.product_id}: ${error.message}`);
+          continue;
+        }
+      }
+
+      // Crear movimiento de stock
+      const { error: movementError } = await supabase
+        .from('stock_movements')
+        .insert({
+          organization_id: organizationId,
+          branch_id: branchId,
+          product_id: item.product_id,
+          lot_id: null,
+          direction: 'in',
+          qty: qty,
+          unit_cost: unitCost,
+          source: source,
+          source_id: String(orderId),
+          updated_by: updatedBy ?? null,
+        });
+
+      if (movementError) {
+        errors.push(`Movimiento producto ${item.product_id}: ${movementError.message}`);
+      }
+    }
+
+    return { success: errors.length === 0, skipped, errors };
+  },
+};

--- a/src/lib/services/webOrderConfirmationService.ts
+++ b/src/lib/services/webOrderConfirmationService.ts
@@ -2,6 +2,7 @@ import { supabase } from '@/lib/supabase/config';
 import { getCurrentUserId } from '@/lib/hooks/useOrganization';
 import { PropinasService } from '@/components/pos/propinas/propinasService';
 import { deliveryIntegrationService } from './deliveryIntegrationService';
+import { stockMovementService } from './stockMovementService';
 import type { WebOrder } from './webOrdersService';
 
 export interface ConfirmOrderResult {
@@ -51,6 +52,38 @@ class WebOrderConfirmationService {
 
     // 2. Crear sale_items y obtener los IDs insertados
     const insertedSaleItems = await this.createSaleItems(order, saleId);
+
+    // 2b. Descontar stock definitivamente y liberar reserva
+    try {
+      const stockResult = await stockMovementService.decrementOnSale(
+        order.organization_id,
+        order.branch_id,
+        saleId,
+        (order.items || []).map(item => ({
+          product_id: item.product_id,
+          quantity: item.quantity,
+          unit_price: item.unit_price,
+        })),
+        'web_sale',
+        userId
+      );
+      if (stockResult.errors.length > 0) {
+        console.warn('⚠️ Algunos items no descontaron stock:', stockResult.errors);
+      }
+      console.log(`📦 Stock descontado (web order confirm): ${(order.items || []).length - stockResult.skipped} items`);
+
+      // Liberar reserva (qty_reserved) ya que el stock fue descontado definitivamente
+      await stockMovementService.releaseStockReservation(
+        order.branch_id,
+        order.id,
+        (order.items || []).map(item => ({
+          product_id: item.product_id,
+          quantity: item.quantity,
+        }))
+      );
+    } catch (stockError) {
+      console.warn('⚠️ Error descontando stock (no bloquea la confirmación):', stockError);
+    }
 
     // 3. Crear kitchen_ticket + kitchen_ticket_items
     const kitchenTicketId = await this.createKitchenTicket(

--- a/src/lib/services/webOrdersService.ts
+++ b/src/lib/services/webOrdersService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabase/config';
 import { getOrganizationId, getCurrentBranchId } from '@/lib/hooks/useOrganization';
+import { stockMovementService } from '@/lib/services/stockMovementService';
 
 export type WebOrderStatus = 'pending' | 'confirmed' | 'preparing' | 'ready' | 'in_delivery' | 'delivered' | 'cancelled' | 'rejected';
 export type DeliveryType = 'pickup' | 'delivery_own' | 'delivery_third_party';
@@ -320,6 +321,22 @@ class WebOrdersService {
 
       if (itemsError) throw itemsError;
 
+      // Reservar stock por cada item con product_id
+      try {
+        const stockResult = await stockMovementService.reserveStock(
+          this.organizationId,
+          input.branch_id,
+          order.id,
+          itemsWithTotals.map(item => ({ product_id: item.product_id, quantity: item.quantity, unit_price: item.unit_price }))
+        );
+        if (stockResult.errors.length > 0) {
+          console.warn('⚠️ Algunos items no reservaron stock:', stockResult.errors);
+        }
+        console.log(`📦 Stock reservado (web order): ${itemsWithTotals.length - stockResult.skipped} items procesados`);
+      } catch (stockError) {
+        console.warn('⚠️ Error reservando stock (no bloquea el pedido):', stockError);
+      }
+
       return this.getOrderById(order.id) as Promise<WebOrder>;
     } catch (error) {
       console.error('Error creating web order:', error);
@@ -435,6 +452,7 @@ class WebOrdersService {
    * Cancelar pedido
    */
   async cancelOrder(orderId: string, reason: string): Promise<WebOrder> {
+    await this.releaseOrderStock(orderId);
     return this.updateOrderStatus(orderId, 'cancelled', { cancellation_reason: reason });
   }
 
@@ -442,7 +460,43 @@ class WebOrdersService {
    * Rechazar pedido
    */
   async rejectOrder(orderId: string, reason: string): Promise<WebOrder> {
+    await this.releaseOrderStock(orderId);
     return this.updateOrderStatus(orderId, 'rejected', { cancellation_reason: reason });
+  }
+
+  /**
+   * Liberar stock reservado de un pedido (al cancelar/rechazar)
+   */
+  private async releaseOrderStock(orderId: string): Promise<void> {
+    try {
+      const { data: order } = await supabase
+        .from('web_orders')
+        .select('branch_id')
+        .eq('id', orderId)
+        .single();
+
+      if (!order) return;
+
+      const { data: items } = await supabase
+        .from('web_order_items')
+        .select('product_id, quantity')
+        .eq('web_order_id', orderId);
+
+      if (!items || items.length === 0) return;
+
+      const stockResult = await stockMovementService.releaseStockReservation(
+        order.branch_id,
+        orderId,
+        items.map((item: any) => ({ product_id: item.product_id, quantity: Number(item.quantity) }))
+      );
+
+      if (stockResult.errors.length > 0) {
+        console.warn('⚠️ Error liberando reservas:', stockResult.errors);
+      }
+      console.log(`📦 Reservas liberadas (web order ${orderId}): ${items.length - stockResult.skipped} items`);
+    } catch (error) {
+      console.warn('⚠️ Error liberando stock reservado (no bloquea cancelación):', error);
+    }
   }
 
   /**


### PR DESCRIPTION
feat(stock): Sistema completo de gestión de stock - Fases 1-5
 
Fase 1: track_stock en products + UI switch
Fase 2: Descuento en ventas POS y mesas (RPC decrement_stock_on_sale)
Fase 3: Reserva de stock en web orders + descuento al confirmar
Fase 4: Recepción de orden de compra (incrementOnPurchase con costo promedio)
Fase 5: PMS/folios conectado con stock (consumo habitación, checkout, reversa)
 
- Nuevo: stockMovementService.ts con decrementOnSale, incrementOnPurchase, reserveStock, releaseStockReservation
- BD: columna track_stock, columna product_id+quantity en folio_items, RPC decrement_stock_on_sale
- posService: descuento en checkout y holdCartWithDebt
- pedidosService: descuento al completar venta de mesa
- webOrdersService: reserva al crear, libera al cancelar/rechazar
- webOrderConfirmationService: descuento + libera reserva al confirmar
- purchaseOrderService: incrementa stock al recibir items (delta)
- foliosService: descuenta al crear folio_item, revierte al eliminar
- spaceConsumptionService: descuenta stock al agregar consumo habitación
- checkoutService: crea sale+sale_items desde folio al checkout