### PR TITLE
fix: normalizar parent_task array de Supabase en PM tasks

### DIFF
--- a/src/components/pm/TaskCreationPanel.tsx
+++ b/src/components/pm/TaskCreationPanel.tsx
@@ -652,7 +652,7 @@ export default function TaskCreationPanel({ isOpen, onClose, projects, existingT
         </div>
 
         {/* Tarea padre (si es subtarea) */}
-        {isEdit && editTask?.parent_task && (
+        {isEdit && editTask?.parent_task?.id && (
           <div className="flex items-center gap-2 bg-indigo-50 dark:bg-indigo-900/20 rounded-lg px-3 py-2 border border-indigo-100 dark:border-indigo-800">
             <GitBranch className="h-4 w-4 text-indigo-500 flex-shrink-0" />
             <div className="flex-1 min-w-0">

--- a/src/components/pm/views/KanbanBoard.tsx
+++ b/src/components/pm/views/KanbanBoard.tsx
@@ -140,7 +140,7 @@ export function KanbanBoard({ tasks, onTaskUpdate, onTaskClick, runningTimers }:
                                   <Badge className={`text-[10px] ${PRIORITY_COLORS[task.priority]}`}>
                                     {PRIORITY_LABELS[task.priority]}
                                   </Badge>
-                                  {task.parent_task && (
+                                  {task.parent_task?.id && (
                                     <button
                                       type="button"
                                       onClick={(e) => { e.stopPropagation(); onTaskClick?.({ ...task, id: task.parent_task!.id, title: task.parent_task!.title }); }}

--- a/src/components/pm/views/TaskListView.tsx
+++ b/src/components/pm/views/TaskListView.tsx
@@ -286,7 +286,7 @@ export function TaskListView({ tasks, onTaskClick, onTaskUpdate, users = [], pro
                         <Bot className="h-2.5 w-2.5 mr-0.5" />Agente
                       </Badge>
                     )}
-                    {task.parent_task && (
+                    {task.parent_task?.id && (
                       <button
                         type="button"
                         onClick={(e) => { e.stopPropagation(); onTaskClick?.({ ...task, id: task.parent_task!.id, title: task.parent_task!.title }); }}

--- a/src/lib/services/pmService.ts
+++ b/src/lib/services/pmService.ts
@@ -441,8 +441,11 @@ export const pmService = {
     const { data, error } = await query;
     if (error) { console.error('Error getTasks:', error.message); return []; }
 
-    // Enriquecer con profiles por separado si hay assigned_to
-    let tasks = data || [];
+    // Normalizar parent_task: Supabase devuelve array en self-referencing joins
+    let tasks = (data || []).map((t: any) => ({
+      ...t,
+      parent_task: Array.isArray(t.parent_task) ? (t.parent_task[0] || null) : t.parent_task
+    }));
 
     // Filtro por módulo (post-query, en cliente)
     if (filters?.module === 'crm') {
@@ -657,8 +660,13 @@ export const pmService = {
   },
 
   async getTaskById(taskId: string): Promise<PMTask | null> {
+    if (!taskId || taskId === 'undefined') { console.error('Error getTaskById: taskId inválido:', taskId); return null; }
     const { data, error } = await supabase.from('tasks').select('*, parent_task:tasks!parent_task_id(id, title, status)').eq('id', taskId).single();
     if (error) { console.error('Error getTaskById:', error.message); return null; }
+    // Normalizar parent_task: Supabase devuelve array en self-referencing joins
+    if (data && Array.isArray(data.parent_task)) {
+      data.parent_task = data.parent_task[0] || null;
+    }
     return data;
   },
 


### PR DESCRIPTION
fix: normalizar parent_task array de Supabase en PM tasks
 
- pmService: normalizar parent_task de array a objeto en getTasks y getTaskById
- pmService: guard para taskId invalido en getTaskById
- KanbanBoard, TaskListView: verificar parent_task?.id
- TaskCreationPanel: verificar parent_task?.id en seccion pertenece a